### PR TITLE
Implement in-place release with -i/--inplace option

### DIFF
--- a/git-flow-release
+++ b/git-flow-release
@@ -222,8 +222,6 @@ cmd_finish() {
 
 	if flag inplace; then
 		BRANCH="$(git_current_branch)"
-		git_remote_branch_exists "$ORIGIN/$DEVELOP_BRANCH" \
-		    && require_branches_equal "$BRANCH" "$DEVELOP_BRANCH"
 	fi
 
 	gitflow_require_version_arg


### PR DESCRIPTION
This implement a solution to issue #133 "Add ability to release directly
from develop".

When in-place is activated:
- the current branch must be merged in the develop branch
- no mergeback occurs
- no branch deletion occurs

The in-place release can be called in two ways:

```
git flow release finish -i <version>
```

or a shorter form:

```
git flow release -i <version>
```
- git-flow-release (cmd_default): Define flags of cmd_list() and
  cmd_finish() to support the shorter call form.
  Call cmd_finish() if inplace is enabled.
  (cmd_list): Avoid warning by redefining the verbose flag if called from
  cmd_default().
  (cmd_finish): Avoid warning by redefining flags if called from
  cmd_default().
  Add filter on the version.
  Do not merge back and delete branch when inplace is enabled
