### PR TITLE
Fix flag test in cmd_delete()

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -569,6 +569,6 @@ cmd_delete() {
 	echo
 	echo "Summary of actions:"
 	echo "- Feature branch '$BRANCH' has been deleted."
-	[ flag remote ] && echo "- Feature branch '$BRANCH' in '$ORIGIN' has been deleted."
+	flag remote && echo "- Feature branch '$BRANCH' in '$ORIGIN' has been deleted."
 	echo
 }

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -373,6 +373,6 @@ cmd_delete() {
 	echo
 	echo "Summary of actions:"
 	echo "- Hotfix branch '$BRANCH' has been deleted."
-	[ flag remote ] && echo "- Hotfix branch '$BRANCH' in '$ORIGIN' has been deleted."
+	flag remote && echo "- Hotfix branch '$BRANCH' in '$ORIGIN' has been deleted."
 	echo
 }

--- a/git-flow-release
+++ b/git-flow-release
@@ -398,6 +398,6 @@ cmd_delete() {
 	echo
 	echo "Summary of actions:"
 	echo "- Release branch '$BRANCH' has been deleted."
-	[ flag remote ] && echo "- Release branch '$BRANCH' in '$ORIGIN' has been deleted."
+	flag remote && echo "- Release branch '$BRANCH' in '$ORIGIN' has been deleted."
 	echo
 }


### PR DESCRIPTION
The release, feature and hotfix delete output a test error:

```
line 573: [: flag: unary operator expected
```

It's errornous to call "flag" in "[ ]".
- git-flow-feature (cmd_delete): Do not use "[ ]".
- git-flow-hotfix (cmd_delete): Ditoo.
- git-flow-release (cmd_delete): Ditoo.
