### PR TITLE
Reorder fetch and sanity checks

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -186,13 +186,13 @@ cmd_start() {
 	BASE=${2:-$DEVELOP_BRANCH}
 	gitflow_require_name_arg
 
-	# Sanity checks
-	require_branch_absent "$BRANCH"
-
 	# Update the local repo with remote changes, if asked
 	if flag fetch; then
 		git fetch -q "$ORIGIN" "$DEVELOP_BRANCH"
 	fi
+
+	# Sanity checks
+	require_branch_absent "$BRANCH"
 
 	# If the origin branch counterpart exists, assert that the local branch
 	# isn't behind it (to avoid unnecessary rebasing)

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -138,6 +138,14 @@ cmd_start() {
 	parse_args "$@"
 	BASE=${2:-$MASTER_BRANCH}
 
+	# No need to continue if not clean
+	require_clean_working_tree
+
+ 	# Update the local repo with remote changes, if asked
+	if flag fetch; then
+		git fetch -q "$ORIGIN" "$MASTER_BRANCH"
+	fi
+
 	# Run filter on the version
 	VERSION=$(run_filter_hook hotfix-start-version $VERSION)
 
@@ -149,12 +157,8 @@ cmd_start() {
 	require_no_existing_hotfix_branches
 
 	# Sanity checks
-	require_clean_working_tree
 	require_branch_absent "$BRANCH"
 	require_tag_absent "$VERSION_PREFIX$VERSION"
-	if flag fetch; then
-		git fetch -q "$ORIGIN" "$MASTER_BRANCH"
-	fi
 	if git_remote_branch_exists "$ORIGIN/$MASTER_BRANCH"; then
 		require_branches_equal "$MASTER_BRANCH" "$ORIGIN/$MASTER_BRANCH"
 	fi

--- a/git-flow-support
+++ b/git-flow-support
@@ -134,7 +134,6 @@ cmd_start() {
 	parse_args "$@"
 	gitflow_require_version_arg
 	gitflow_require_base_arg
-	git_is_ancestor "$BASE" "$MASTER_BRANCH" || die "Given base '$BASE' is not a valid commit on '$MASTER_BRANCH'."
 
 	# Sanity checks
 	require_clean_working_tree
@@ -143,6 +142,9 @@ cmd_start() {
 	if flag fetch; then
 		git fetch -q "$ORIGIN" "$BASE"
 	fi
+
+	git_is_ancestor "$BASE" "$MASTER_BRANCH" || die "Given base '$BASE' is not a valid commit on '$MASTER_BRANCH'."
+
 	require_branch_absent "$BRANCH"
 
 	# Create branch


### PR DESCRIPTION
A user ask for a fetch to base on latest remote commit or to avoid any
conflict in branch names and/or version.
- git-flow-feature (cmd_start): Move optional fetch at the top, only name
  argument has higher priority.
- git-flow-hotfix (cmd_start): Abort early if working tree is not clean.
  Move optional fetch at the top, the version filter can use up-to-date
  informations.
- git-flow-support (cmd_start): Move ancestry check after optional fetch
  to get latest $BASE if it's a remote one.
