### PR TITLE
Honor "keep" flag when pushing at "release finish" time

### DIFF
--- a/git-flow-release
+++ b/git-flow-release
@@ -281,8 +281,8 @@ cmd_finish() {
 		fi
 		if noflag keep && git_remote_branch_exists "$ORIGIN/$BRANCH"; then
 			git push "$ORIGIN" :"$BRANCH" || die "Could not delete the remote $BRANCH in $ORIGIN."
-		elif flag keep
-			git push "$ORIGIN" "$BRANCH" || die "Could not update the remote $BRANCH in $ORIGIN."
+		else
+			git push "$ORIGIN" "$BRANCH" || die "Could not push to $BRANCH from $ORIGIN."
 		fi
 	fi
 


### PR DESCRIPTION
- git-flow-release (cmd_finish): Delete the release branch on remote only
  if the keep flag was not passed.
  In the other case, update the remote branch.
