### PR TITLE
hotfix/release/support start does not accept tags as base

### DIFF
--- a/gitflow-common
+++ b/gitflow-common
@@ -167,7 +167,8 @@ git_is_branch_merged_into() {
 # for readibilty given a different name.
 #
 git_is_ancestor() {
-	git_is_branch_merged_into $1 $2
+	git_tag_exists "$1" && git_is_branch_merged_into "$1"^0 "$2" \
+	    || git_is_branch_merged_into "$1" "$2"
 }
 #
 # gitflow specific common functionality


### PR DESCRIPTION
Commit pointed by tags are reachable with <rev>^0[1].
- gitflow-common (git_is_ancestor): Dereference tags.

Footnotes:
[1]  https://www.kernel.org/pub/software/scm/git/docs/git-rev-parse.html
