### PR TITLE
Usage of positional parameters requires to eval ${FLAGS_ARGV}

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -194,6 +194,7 @@ parse_remote_name() {
 cmd_start() {
 	DEFINE_boolean fetch false 'fetch from origin before performing local operation' F
 	parse_args "$@"
+	eval set -- "${FLAGS_ARGV}"
 	BASE=${2:-$DEVELOP_BRANCH}
 	require_name_arg
 

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -156,6 +156,7 @@ require_no_existing_hotfix_branches() {
 cmd_start() {
 	DEFINE_boolean fetch false "fetch from $ORIGIN before performing finish" F
 	parse_args "$@"
+	eval set -- "${FLAGS_ARGV}"
 	BASE=${2:-$MASTER_BRANCH}
 	require_version_arg
 	require_base_is_on_master

--- a/git-flow-release
+++ b/git-flow-release
@@ -152,6 +152,7 @@ require_no_existing_release_branches() {
 cmd_start() {
 	DEFINE_boolean fetch false "fetch from $ORIGIN before performing finish" F
 	parse_args "$@"
+	eval set -- "${FLAGS_ARGV}"
 	BASE=${2:-$DEVELOP_BRANCH}
 	require_version_arg
 	require_base_is_on_develop


### PR DESCRIPTION
The "eval set" in function call does not propagate to the caller.
- git-flow-feature (cmd_start): Eval ${FLAGS_ARGV} as positional
  parameters.
- git-flow-hotfix (cmd_start): Ditoo.
- git-flow-release (cmd_start): Ditoo
