### PR TITLE
To finish a hotfix, the tag must not exists or have hotfix HEAD as its s...

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -287,6 +287,17 @@ cmd_finish() {
 		*) ;;
 	esac
 
+	if noflag notag; then
+		# We ask for a tag, be sure it does not exists or
+		# points to the latest hotfix commit
+		if git_tag_exists "$VERSION_PREFIX$VERSION"; then
+			local hotfix_sha=$(git rev-parse "$BRANCH")
+			local tag_parent_sha=$(git rev-parse "$VERSION_PREFIX$VERSION"^2)
+			[ "$hotfix_sha" = "$tag_parent_sha" ] \
+			    || die "Tag already exists and does not point to hotfix branch '$BRANCH'"
+		fi
+	fi
+
 	run_pre_hook "$VERSION_PREFIX$VERSION" "$ORIGIN" "$BRANCH"
 
 	# Try to merge into master.


### PR DESCRIPTION
...econd parent

This can arrive when multiple "local" hotfix branches will be supported or actually
with the multiple "remote team" hotfix branches.
- git-flow-hotfix (cmd_finish): Die if an existing tags exists and its
  second parent is not the hotfix HEAD.
