### PR TITLE
No branch is deleted when --inplace option is set

### DIFF
--- a/git-flow-release
+++ b/git-flow-release
@@ -359,7 +359,7 @@ cmd_finish() {
 	[ "$commit" = "$VERSION_PREFIX$VERSION" ] && echo "- Release tag '$VERSION_PREFIX$VERSION' has been back-merged into '$DEVELOP_BRANCH'"
 	[ "$commit" = "$BRANCH" ] && echo "- Release branch '$BRANCH' has been merged into '$DEVELOP_BRANCH'"
 
-	if noflag keep; then
+	if noflag keep && noflag inplace; then
 		keepmsg="'has been deleted"
 		if flag keeplocal; then
 			 local keepmsg="is locally still available."


### PR DESCRIPTION
- git-flow-release: Fix summary when --inplace option is passed, no
  branch is deleted even without any --keep\* option.
