### PR TITLE
Display where user is on finish

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -608,5 +608,6 @@ cmd_delete() {
 	echo "Summary of actions:"
 	echo "- Feature branch '$BRANCH' has been deleted."
 	flag remote && echo "- Feature branch '$BRANCH' in '$ORIGIN' has been deleted."
+	echo "- You are now on branch '$(git_current_branch)'"
 	echo
 }

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -401,6 +401,7 @@ cmd_finish() {
 	if flag push; then
 		echo "- '$DEVELOP_BRANCH', '$MASTER_BRANCH' and tags have been pushed to '$ORIGIN'"
 	fi
+	echo "- You are now on branch '$(git_current_branch)'"
 	echo
 }
 
@@ -444,5 +445,6 @@ cmd_delete() {
 	echo "Summary of actions:"
 	echo "- Hotfix branch '$BRANCH' has been deleted."
 	flag remote && echo "- Hotfix branch '$BRANCH' in '$ORIGIN' has been deleted."
+	echo "- You are now on branch '$(git_current_branch)'"
 	echo
 }

--- a/git-flow-release
+++ b/git-flow-release
@@ -371,6 +371,7 @@ cmd_finish() {
 	if flag push; then
 		echo "- '$DEVELOP_BRANCH', '$MASTER_BRANCH' and tags have been pushed to '$ORIGIN'"
 	fi
+	echo "- You are now on branch '$(git_current_branch)'"
 	echo
 }
 
@@ -484,6 +485,7 @@ cmd_branch() {
 	if flag push; then
 		echo "- '$MASTER_BRANCH' and tags have been pushed to '$ORIGIN'"
 	fi
+	echo "- You are now on branch '$(git_current_branch)'"
 	echo
 }
 
@@ -582,5 +584,6 @@ cmd_delete() {
 	echo "Summary of actions:"
 	echo "- Release branch '$BRANCH' has been deleted."
 	flag remote && echo "- Release branch '$BRANCH' in '$ORIGIN' has been deleted."
+	echo "- You are now on branch '$(git_current_branch)'"
 	echo
 }


### PR DESCRIPTION
It is useful to display on which branch the user is after doing some
merge or delete.
- git-flow-feature: Dispaly the current branch name on finish and delete.
- git-flow-hotfix: Ditoo.
- git-flow-release: Display the current branch name on finish, branch and
  delete.

fixes petervanderdoes/gitflow#24
