### PR TITLE
Make production release branch optional

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -59,6 +59,13 @@ cmd_list() {
 	DEFINE_boolean verbose false 'verbose (more) output' v
 	parse_args "$@"
 
+	# Handle disabled master
+	if gitflow_has_master_disabled; then
+		UPSTREAM_BRANCH="$DEVELOP_BRANCH"
+	else
+		UPSTREAM_BRANCH="$MASTER_BRANCH"
+	fi
+
 	local hotfix_branches
 	local current_branch
 	hotfix_branches=$(git_local_branches_prefixed "$PREFIX")
@@ -84,8 +91,8 @@ cmd_list() {
 
 	local branch
 	for branch in $hotfix_branches; do
-		local base=$(git merge-base "$branch" "$MASTER_BRANCH")
-		local master_sha=$(git rev-parse "$MASTER_BRANCH")
+		local base=$(git merge-base "$branch" "$UPSTREAM_BRANCH")
+		local upstream_sha=$(git rev-parse "$UPSTREAM_BRANCH")
 		local branch_sha=$(git rev-parse "$branch")
 		if [ "$branch" = "$current_branch" ]; then
 			printf "* "
@@ -94,7 +101,7 @@ cmd_list() {
 		fi
 		if flag verbose; then
 			printf "%-${width}s" "${branch#$PREFIX}"
-			if [ "$branch_sha" = "$master_sha" ]; then
+			if [ "$branch_sha" = "$upstream_sha" ]; then
 				printf "(no commits yet)"
 			else
 				local tagname=$(git name-rev --tags --no-undefined --name-only "$base")
@@ -139,14 +146,21 @@ cmd_start() {
 	DEFINE_boolean fetch false "fetch from $ORIGIN before performing finish" F
 	parse_args "$@"
 	eval set -- "${FLAGS_ARGV}"
-	BASE=${2:-$MASTER_BRANCH}
+
+	# Handle disabled master
+	if gitflow_has_master_disabled; then
+		UPSTREAM_BRANCH="$DEVELOP_BRANCH"
+	else
+		UPSTREAM_BRANCH="$MASTER_BRANCH"
+	fi
+	BASE=${2:-$UPSTREAM_BRANCH}
 
 	# No need to continue if not clean
 	require_clean_working_tree
 
- 	# Update the local repo with remote changes, if asked
+	# Update the local repo with remote changes, if asked
 	if flag fetch; then
-		git_fetch_branch "$ORIGIN" "$MASTER_BRANCH"
+		git_fetch_branch "$ORIGIN" "$UPSTREAM_BRANCH"
 	fi
 
 	# Run filter on the version
@@ -156,14 +170,14 @@ cmd_start() {
 	BRANCH=$PREFIX$VERSION
 
 	gitflow_require_version_arg
-	git_is_ancestor "$BASE" "$MASTER_BRANCH" || die "Given base '$BASE' is not a valid commit on '$MASTER_BRANCH'."
+	git_is_ancestor "$BASE" "$UPSTREAM_BRANCH" || die "Given base '$BASE' is not a valid commit on '$UPSTREAM_BRANCH'."
 	require_no_existing_hotfix_branches
 
 	# Sanity checks
 	require_branch_absent "$BRANCH"
 	require_tag_absent "$VERSION_PREFIX$VERSION"
-	if git_remote_branch_exists "$ORIGIN/$MASTER_BRANCH"; then
-		require_branches_equal "$MASTER_BRANCH" "$ORIGIN/$MASTER_BRANCH"
+	if git_remote_branch_exists "$ORIGIN/$UPSTREAM_BRANCH"; then
+		require_branches_equal "$UPSTREAM_BRANCH" "$ORIGIN/$UPSTREAM_BRANCH"
 	fi
 
 	run_pre_hook "$VERSION_PREFIX$VERSION" "$ORIGIN" "$BRANCH" "$BASE"
@@ -234,6 +248,13 @@ cmd_finish() {
 	parse_args "$@"
 	gitflow_require_version_arg
 
+	# Handle disabled master
+	if gitflow_has_master_disabled; then
+		UPSTREAM_BRANCH="$DEVELOP_BRANCH"
+	else
+		UPSTREAM_BRANCH="$MASTER_BRANCH"
+	fi
+
 	# Handle flags that imply other flags
 	if [ "$FLAGS_signingkey" != "" ]; then
 		FLAGS_sign=$FLAGS_TRUE
@@ -257,18 +278,18 @@ cmd_finish() {
 
 	# Update local branches with remote branches
 	if flag fetch; then
-		git_fetch_branch "$ORIGIN" "$MASTER_BRANCH"
-		git_fetch_branch "$ORIGIN" "$DEVELOP_BRANCH"
+		git_fetch_branch "$ORIGIN" "$UPSTREAM_BRANCH"
+		gitflow_has_master_disabled || git_fetch_branch "$ORIGIN" "$DEVELOP_BRANCH"
 	fi
 
 	# Check if the local branches have all the commits from the remote branches
 	if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
 		require_branches_equal "$BRANCH" "$ORIGIN/$BRANCH"
 	fi
-	if git_remote_branch_exists "$ORIGIN/$MASTER_BRANCH"; then
-		require_branches_equal "$MASTER_BRANCH" "$ORIGIN/$MASTER_BRANCH"
+	if git_remote_branch_exists "$ORIGIN/$UPSTREAM_BRANCH"; then
+		require_branches_equal "$UPSTREAM_BRANCH" "$ORIGIN/$UPSTREAM_BRANCH"
 	fi
-	if git_remote_branch_exists "$ORIGIN/$DEVELOP_BRANCH"; then
+	if ! gitflow_has_master_disabled && git_remote_branch_exists "$ORIGIN/$DEVELOP_BRANCH"; then
 		require_branches_equal "$DEVELOP_BRANCH" "$ORIGIN/$DEVELOP_BRANCH"
 	fi
 
@@ -276,24 +297,24 @@ cmd_finish() {
 	# - has commits: No reason to finish a hotfix without commits
 	# - Is ahead of the master: If it's not a good idea to merge
 	# - Can be merged: If there's no common ancestor we can't merge the hotfix
-	git_compare_branches "$BRANCH" "$MASTER_BRANCH"
+	git_compare_branches "$BRANCH" "$UPSTREAM_BRANCH"
 	case $? in
 		0) die "You need some commits in the hotfix branch '$BRANCH'"
 		   ;;
-		1) die "The hotfix branch '$BRANCH' is not ahead of branch '$MASTER_BRANCH'"
+		1) die "The hotfix branch '$BRANCH' is not ahead of branch '$UPSTREAM_BRANCH'"
 		   ;;
-		4) die "The hotfix branch '$BRANCH' has no common ancestor with branch '$MASTER_BRANCH'"
+		4) die "The hotfix branch '$BRANCH' has no common ancestor with branch '$UPSTREAM_BRANCH'"
 		   ;;
 		*) ;;
 	esac
 
 	run_pre_hook "$VERSION_PREFIX$VERSION" "$ORIGIN" "$BRANCH"
 
-	# Try to merge into master.
+	# Try to merge into upstream branch
 	# In case a previous attempt to finish this release branch has failed,
 	# but the merge into master was successful, we skip it now
-	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
-		git checkout "$MASTER_BRANCH" || die "Could not check out branch '$MASTER_BRANCH'."
+	if ! git_is_branch_merged_into "$BRANCH" "$UPSTREAM_BRANCH"; then
+		git checkout "$UPSTREAM_BRANCH" || die "Could not check out branch '$UPSTREAM_BRANCH'."
 		git merge --no-ff "$BRANCH" || die "There were merge conflicts."
 		  # TODO: What do we do now?
 	fi
@@ -315,34 +336,36 @@ cmd_finish() {
 		fi
 	fi
 
-	# By default we back-merge the $MASTER_BRANCH unless the user explicitly
-	# stated not to do a back-merge, in that case we use the $BRANCH.
-	if noflag nobackmerge; then
-		MERGE_BRANCH="$MASTER_BRANCH"
-	else
-		MERGE_BRANCH="$BRANCH"
-	fi
-
-	# Try to merge into develop.
-	# In case a previous attempt to finish this release branch has failed,
-	# but the merge into develop was successful, we skip it now
-	if ! git_is_branch_merged_into "$MERGE_BRANCH" "$DEVELOP_BRANCH"; then
-		git checkout "$DEVELOP_BRANCH" || die "Could not check out branch '$DEVELOP_BRANCH'."
-
+	# By default we backmerge the $UPSTREAM_BRANCH unless the user explicitly
+	# stated not to do a back merge, in that case we use the $BRANCH.
+	if ! gitflow_has_master_disabled; then
 		if noflag nobackmerge; then
-			# Accounting for 'git describe', if a release is tagged
-			# we use the tag commit instead of the branch.
-			if noflag notag; then
-				commit="$VERSION_PREFIX$VERSION"
-			else
-				commit="$MASTER_BRANCH"
-			fi
+			MERGE_BRANCH="$UPSTREAM_BRANCH"
 		else
-			commit="$BRANCH"
+			MERGE_BRANCH="$BRANCH"
 		fi
 
-		git merge --no-ff "$commit" || die "There were merge conflicts."
-		  # TODO: What do we do now?
+		# Try to merge into develop.
+		# In case a previous attempt to finish this release branch has failed,
+		# but the merge into develop was successful, we skip it now
+		if ! git_is_branch_merged_into "$MERGE_BRANCH" "$DEVELOP_BRANCH"; then
+			git checkout "$DEVELOP_BRANCH" || die "Could not check out $DEVELOP_BRANCH."
+
+			if noflag nobackmerge; then
+				# Accounting for 'git describe', if a release is tagged
+				# we use the tag commit instead of the branch.
+				if noflag notag; then
+					commit="$VERSION_PREFIX$VERSION"
+				else
+					commit="$UPSTREAM_BRANCH"
+				fi
+			else
+				commit="$BRANCH"
+			fi
+
+			git merge --no-ff "$commit" || die "There were merge conflicts."
+			  # TODO: What do we do now?
+		fi
 	fi
 
 	run_post_hook "$VERSION_PREFIX$VERSION" "$ORIGIN" "$BRANCH"
@@ -362,8 +385,9 @@ cmd_finish() {
 	fi
 
 	if flag push; then
-		git push "$ORIGIN" "$DEVELOP_BRANCH" || die "Could not push branch '$DEVELOP_BRANCH' to remote '$ORIGIN'."
-		git push "$ORIGIN" "$MASTER_BRANCH" || die "Could not push branch '$MASTER_BRANCH' to remote '$ORIGIN'."
+		git push "$ORIGIN" "$UPSTREAM_BRANCH" || die "Could not push branch '$UPSTREAM_BRANCH' to remote '$ORIGIN'."
+		gitflow_has_master_disabled || \
+		    git push "$ORIGIN" "$DEVELOP_BRANCH" || die "Could not push branch '$DEVELOP_BRANCH' to remote '$ORIGIN'."
 		if noflag notag; then
 			git push --tags "$ORIGIN" || die "Could not push tags to remote '$ORIGIN'."
 		fi
@@ -374,13 +398,25 @@ cmd_finish() {
 	if flag fetch; then
 		echo "- Latest objects have been fetched from '$ORIGIN'"
 	fi
-	echo "- Hotfix branch '$BRANCH'has been merged into '$MASTER_BRANCH'"
+	echo "- Hotfix branch '$BRANCH' has been merged into '$UPSTREAM_BRANCH'"
 	if noflag notag; then
 		echo "- The hotfix was tagged '$VERSION_PREFIX$VERSION'"
 	fi
-	[ "$commit" = "$MASTER_BRANCH" ] && echo "- Master branch '$MASTER_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
-	[ "$commit" = "$VERSION_PREFIX$VERSION" ] && echo "- Hotfix tag '$VERSION_PREFIX$VERSION' has been back-merged into '$DEVELOP_BRANCH'"
-	[ "$commit" = "$BRANCH" ] && echo "- Hotfix branch '$BRANCH' has been merged into '$DEVELOP_BRANCH'"
+	if gitflow_has_master_disabled; then
+		if flag push; then
+			echo "- '$DEVELOP_BRANCH' and tags have been pushed to '$ORIGIN'"
+		fi
+	else
+		[ "$commit" = "$MASTER_BRANCH" ] \
+		    && echo "- Master branch '$MASTER_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
+		[ "$commit" = "$VERSION_PREFIX$VERSION" ] \
+		    && echo "- Hotfix tag '$VERSION_PREFIX$VERSION' has been back-merged into '$DEVELOP_BRANCH'"
+		[ "$commit" = "$BRANCH" ] \
+		    && echo "- Hotfix branch '$BRANCH' has been merged into '$DEVELOP_BRANCH'"
+		if flag push; then
+			echo "- '$DEVELOP_BRANCH', '$MASTER_BRANCH' and tags have been pushed to '$ORIGIN'"
+		fi
+	fi
 	if noflag keep; then
 		local keepmsg="'has been deleted"
 		if flag keeplocal; then
@@ -398,9 +434,6 @@ cmd_finish() {
 		keepmsg="is still available"
 	fi
 	echo "- Hotfix branch '$BRANCH' "$keepmsg
-	if flag push; then
-		echo "- '$DEVELOP_BRANCH', '$MASTER_BRANCH' and tags have been pushed to '$ORIGIN'"
-	fi
 	echo "- You are now on branch '$(git_current_branch)'"
 	echo
 }
@@ -411,19 +444,27 @@ cmd_delete() {
 	parse_args "$@"
 	gitflow_require_version_arg
 
+	# Handle disabled master
+	if gitflow_has_master_disabled; then
+		UPSTREAM_BRANCH="$DEVELOP_BRANCH"
+	else
+		UPSTREAM_BRANCH="$MASTER_BRANCH"
+	fi
+
 	# Sanity checks
 	require_branch "$BRANCH"
 
 	run_pre_hook "$VERSION" "$ORIGIN" "$BRANCH"
 
 	local current_branch=$(git_current_branch)
-	# We can't delete a branch we are on, switch to the master branch.
+	# We can't delete a branch we are on, switch to the "upstream" branch.
 	if [ "$BRANCH" = "$current_branch" ]; then
 		require_clean_working_tree
-		git checkout "$MASTER_BRANCH" || die "Could not check out branch '$MASTER_BRANCH'."
+		git checkout "$UPSTREAM_BRANCH" || die "Could not check out branch '$UPSTREAM_BRANCH'."
 	fi
 
-	if ( git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH" && git_is_branch_merged_into "$BRANCH" "$DEVELOP_BRANCH" ); then
+	if (gitflow_has_master_disabled || git_is_branch_merged_into "$BRANCH" "$DEVELOP_BRANCH") \
+	    && git_is_branch_merged_into "$BRANCH" "$UPSTREAM_BRANCH"; then
 		git branch -d "$BRANCH" || die "Could not delete the $BRANCH."
 		if flag remote; then
 			git push "$ORIGIN" :"$BRANCH" || die "Could not delete the remote $BRANCH in $ORIGIN."
@@ -435,9 +476,13 @@ cmd_delete() {
 				git push "$ORIGIN" :"$BRANCH" || die "Could not delete the remote $BRANCH in $ORIGIN."
 			fi
 		else
-			 die "Hotfix branch '$BRANCH' has been not been merged in branch '$MASTER_BRANCH' and/or branch '$DEVELOP_BRANCH'. Use -f to force the deletion."
-		 fi
-	 fi
+			if gitflow_has_master_disabled; then
+				die "Hotfix branch '$BRANCH' has been not been merged in develop branch '$DEVELOP_BRANCH'. Use -f to force the deletion."
+			else
+				die "Hotfix branch '$BRANCH' has been not been merged in master '$MASTER_BRANCH' and/or develop branch '$DEVELOP_BRANCH'. Use -f to force the deletion."
+			fi
+		fi
+	fi
 
 	 run_post_hook "$VERSION" "$ORIGIN" "$BRANCH"
 

--- a/git-flow-init
+++ b/git-flow-init
@@ -36,7 +36,7 @@
 #
 
 usage() {
-	echo "usage: git flow init [-fd]"
+	echo "usage: git flow init [-fdm]"
 }
 
 parse_args() {
@@ -49,6 +49,7 @@ parse_args() {
 cmd_default() {
 	DEFINE_boolean force false 'force setting of gitflow branches, even if already configured' f
 	DEFINE_boolean defaults false 'use default branch naming conventions' d
+	DEFINE_boolean nomaster false 'disable the creation of production release branch' m
 	parse_args "$@"
 
 	if ! git rev-parse --git-dir >/dev/null 2>&1; then
@@ -74,7 +75,9 @@ cmd_default() {
 
 	# Add a master branch if no such branch exists yet
 	local master_branch
-	if gitflow_has_master_configured && ! flag force; then
+	if (flag nomaster || gitflow_has_master_disabled) && noflag force; then
+		git config --bool gitflow.branch.master.disabled true
+	elif gitflow_has_master_configured && noflag force; then
 		master_branch=$(git config --get gitflow.branch.master)
 	else
 		# Two cases are distinguished:
@@ -113,24 +116,45 @@ cmd_default() {
 		fi
 		master_branch=${answer:-$default_suggestion}
 
-		# Check existence in case of an already existing repo
-		if [ "$should_check_existence" = "YES" ]; then
-			# If no local branch exists and a remote branch of the same
-			# name exists, checkout that branch and use it for master
-			if ! git_local_branch_exists "$master_branch" && git_remote_branch_exists "origin/$master_branch"; then
-				git branch "$master_branch" "origin/$master_branch" >/dev/null 2>&1
-			elif ! git_local_branch_exists "$master_branch"; then
-				die "Local branch '$master_branch' does not exist."
-			fi
+		# disabling/enabling
+		if [ -n "$master_branch" ] && gitflow_has_master_disabled; then
+			echo "Warning: production release branch was disabled."
+			default_suggestion="Yes"
+			printf "Do you want to enable production release branch (Yes/No): [$default_suggestion] "
+			read answer
+			answer=${answer:-$default_suggestion}
+			[ "$answer" = "Yes" ] && git config --bool gitflow.branch.master.disabled false
+		elif [ -z "$master_branch" ]; then
+			echo "Warning: no production release branch name defined "
+			default_suggestion="No"
+			printf "Do you want to disable production release branch (No/Yes): [$default_suggestion] "
+			read answer
+			[ "$answer" = "Yes" ] || die "No production release branch defined."
+			git config gitflow.branch.master.disabled true
 		fi
 
-		# Store the name of the master branch
-		git config gitflow.branch.master "$master_branch"
+		if ! gitflow_has_master_disabled; then
+			# Check existence in case of an already existing repo
+			if [ "$should_check_existence" = "YES" ]; then
+				# If no local branch exists and a remote branch of the same
+				# name exists, checkout that branch and use it for master
+				if ! git_local_branch_exists "$master_branch" \
+				    && git_remote_branch_exists "origin/$master_branch"; then
+					git branch "$master_branch" "origin/$master_branch" >/dev/null 2>&1
+				elif ! git_local_branch_exists "$master_branch"; then
+					die "Local branch '$master_branch' does not exist."
+				fi
+			fi
+
+			# Store the name of the master branch
+			git config gitflow.branch.master "$master_branch"
+		fi
 	fi
 
 	# Add a develop branch if no such branch exists yet
 	local develop_branch
-	if gitflow_has_develop_configured && ! flag force; then
+	if gitflow_has_develop_configured \
+	    && [ "$master_branch" != $(git config --get gitflow.branch.develop) ] && ! flag force; then
 		develop_branch=$(git config --get gitflow.branch.develop)
 	else
 		# Again, the same two cases as with the master selection are
@@ -171,7 +195,12 @@ cmd_default() {
 		develop_branch=${answer:-$default_suggestion}
 
 		if [ "$master_branch" = "$develop_branch" ]; then
-			die "Production and integration branches should differ."
+			echo "Warning: your production and \"next release\" development branches are the same."
+			default_suggestion="No"
+			printf "Do you want to disable production release branch (No/Yes): [$default_suggestion] "
+			read answer
+			[ "$answer" = "Yes" ] || die "Production and integration branches should differ."
+			git config gitflow.branch.master.disabled true
 		fi
 
 		# Check existence in case of an already existing repo
@@ -189,16 +218,21 @@ cmd_default() {
 	# it to be able to create new branches.
 	local created_gitflow_branch=0
 	if ! git rev-parse --quiet --verify HEAD >/dev/null 2>&1; then
-		git symbolic-ref HEAD "refs/heads/$master_branch"
+		if gitflow_has_master_disabled; then
+			git symbolic-ref HEAD "refs/heads/$develop_branch"
+		else
+			git symbolic-ref HEAD "refs/heads/$master_branch"
+		fi
 		git commit --allow-empty --quiet -m "Initial commit"
 		created_gitflow_branch=1
 	fi
 
 	# Creation of master
 	# ------------------
-	# At this point, there always is a master branch: either it existed already
-	# (and was picked interactively as the production branch) or it has just
-	# been created in a fresh repo
+	# At this point, the master branch is disabled or there always
+	# is a master branch: either it existed already (and was
+	# picked interactively as the production branch) or it has
+	# just been created in a fresh repo
 
 	# Creation of develop
 	# -------------------

--- a/git-flow-release
+++ b/git-flow-release
@@ -198,6 +198,14 @@ cmd_finish() {
 	DEFINE_boolean squash false "squash release during merge" S
 
 	parse_args "$@"
+
+	# Handle disabled master
+	if gitflow_has_master_disabled; then
+		UPSTREAM_BRANCH="$DEVELOP_BRANCH"
+	else
+		UPSTREAM_BRANCH="$MASTER_BRANCH"
+	fi
+
 	# Run filter on the version
 	VERSION=$(run_filter_hook release-finish-version $VERSION)
 
@@ -229,28 +237,28 @@ cmd_finish() {
 
 	# Update local branches with remote branches
 	if flag fetch; then
-		git_fetch_branch "$ORIGIN" "$MASTER_BRANCH"
-		git_fetch_branch "$ORIGIN" "$DEVELOP_BRANCH"
+		git_fetch_branch "$ORIGIN" "$UPSTREAM_BRANCH"
+		gitflow_has_master_disabled || git_fetch_branch "$ORIGIN" "$DEVELOP_BRANCH"
 	fi
 
 	# Check if the local branches have all the commits from the remote branches
 	if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
 		require_branches_equal "$BRANCH" "$ORIGIN/$BRANCH"
 	fi
-	if git_remote_branch_exists "$ORIGIN/$MASTER_BRANCH"; then
-		require_branches_equal "$MASTER_BRANCH" "$ORIGIN/$MASTER_BRANCH"
+	if git_remote_branch_exists "$ORIGIN/$UPSTREAM_BRANCH"; then
+		require_branches_equal "$UPSTREAM_BRANCH" "$ORIGIN/$UPSTREAM_BRANCH"
 	fi
-	if git_remote_branch_exists "$ORIGIN/$DEVELOP_BRANCH"; then
+	if ! gitflow_has_master_disabled && git_remote_branch_exists "$ORIGIN/$DEVELOP_BRANCH"; then
 		require_branches_equal "$DEVELOP_BRANCH" "$ORIGIN/$DEVELOP_BRANCH"
 	fi
 
 	run_pre_hook "$VERSION_PREFIX$VERSION" "$ORIGIN" "$BRANCH"
 
-	# Try to merge into master.
+	# Try to merge into upstream.
 	# In case a previous attempt to finish this release branch has failed,
 	# but the merge into master was successful, we skip it now
-	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
-			git checkout "$MASTER_BRANCH" || die "Could not check out branch '$MASTER_BRANCH'."
+	if ! git_is_branch_merged_into "$BRANCH" "$UPSTREAM_BRANCH"; then
+			git checkout "$UPSTREAM_BRANCH" || die "Could not check out branch '$UPSTREAM_BRANCH'."
 			if noflag squash; then
 				git merge --no-ff "$BRANCH" || die "There were merge conflicts." # TODO: What do we do now?
 			else
@@ -276,37 +284,40 @@ cmd_finish() {
 		fi
 	fi
 
-	# By default we backmerge the $MASTER_BRANCH unless the user explicitly
-	# stated not to do a back merge, in that case we use the $BRANCH.
-	if noflag nobackmerge; then
-		MERGE_BRANCH="$MASTER_BRANCH"
-	else
-		MERGE_BRANCH="$BRANCH"
-	fi
-
-	# Try to merge into develop.
-	# In case a previous attempt to finish this release branch has failed,
-	# but the merge into develop was successful, we skip it now
-	if ! git_is_branch_merged_into "$MERGE_BRANCH" "$DEVELOP_BRANCH"; then
-		git checkout "$DEVELOP_BRANCH" || die "Could not check out branch '$DEVELOP_BRANCH'."
-
+	# Useless to merge into develop if master is disabled
+	if ! gitflow_has_master_disabled; then
+		# By default we backmerge the $UPSTREAM_BRANCH unless the user explicitly
+		# stated not to do a back merge, in that case we use the $BRANCH.
 		if noflag nobackmerge; then
-			# Accounting for 'git describe', if a release is tagged
-			# we use the tag commit instead of the branch.
-			if noflag notag; then
-				commit="$VERSION_PREFIX$VERSION"
-			else
-				commit="$MASTER_BRANCH"
-			fi
+			MERGE_BRANCH="$UPSTREAM_BRANCH"
 		else
-			commit="$BRANCH"
+			MERGE_BRANCH="$BRANCH"
 		fi
 
-		if noflag squash; then
-			git merge --no-ff "$commit" || die "There were merge conflicts." # TODO: What do we do now?
-		else
-			git merge --squash "$commit" || die "There were merge conflicts." # TODO: What do we do now?
-			git commit
+		# Try to merge into develop.
+		# In case a previous attempt to finish this release branch has failed,
+		# but the merge into develop was successful, we skip it now
+		if ! git_is_branch_merged_into "$MERGE_BRANCH" "$DEVELOP_BRANCH"; then
+			git checkout "$DEVELOP_BRANCH" || die "Could not check out $DEVELOP_BRANCH."
+
+			if noflag nobackmerge; then
+				# Accounting for 'git describe', if a release is tagged
+				# we use the tag commit instead of the branch.
+				if noflag notag; then
+					commit="$VERSION_PREFIX$VERSION"
+				else
+					commit="$MASTER_BRANCH"
+				fi
+			else
+				commit="$BRANCH"
+			fi
+
+			if noflag squash; then
+				git merge --no-ff "$commit" || die "There were merge conflicts." # TODO: What do we do now?
+			else
+				git merge --squash "$commit" || die "There were merge conflicts." # TODO: What do we do now?
+				git commit
+			fi
 		fi
 	fi
 
@@ -315,7 +326,7 @@ cmd_finish() {
 	# Delete branch
 	if noflag keep; then
 		if [ "$BRANCH" = "$(git_current_branch)" ]; then
-			git checkout "$MASTER_BRANCH" || die "Could not check out branch '$MASTER_BRANCH'."
+			git checkout "$UPSTREAM_BRANCH" || die "Could not check out branch '$UPSTREAM_BRANCH'."
 		fi
 		if noflag keeplocal; then
 			git branch -d "$BRANCH"
@@ -330,8 +341,9 @@ cmd_finish() {
 	fi
 
 	if flag push; then
-		git push "$ORIGIN" "$DEVELOP_BRANCH" || die "Could not push branch '$DEVELOP_BRANCH' to remote '$ORIGIN'."
-		git push "$ORIGIN" "$MASTER_BRANCH" || die "Could not push branch '$MASTER_BRANCH' to remote '$ORIGIN'."
+		git push "$ORIGIN" "$UPSTREAM_BRANCH" || die "Could not push branch '$UPSTREAM_BRANCH' to remote '$ORIGIN'."
+		gitflow_has_master_disabled || \
+		    git push "$ORIGIN" "$DEVELOP_BRANCH" || die "Could not push branch '$DEVELOP_BRANCH' to remote '$ORIGIN'."
 		if noflag notag; then
 			git push --tags "$ORIGIN" || die "Could not push tags to remote '$ORIGIN'."
 		fi
@@ -342,14 +354,25 @@ cmd_finish() {
 	if flag fetch; then
 		echo "- Latest objects have been fetched from '$ORIGIN'"
 	fi
-	echo "- Release branch '$BRANCH' has been merged into '$MASTER_BRANCH'"
+	echo "- Release branch '$BRANCH' has been merged into '$UPSTREAM_BRANCH'"
 	if noflag notag; then
 		echo "- The release was tagged '$VERSION_PREFIX$VERSION'"
 	fi
-	[ "$commit" = "$MASTER_BRANCH" ] && echo "- Master branch '$MASTER_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
-	[ "$commit" = "$VERSION_PREFIX$VERSION" ] && echo "- Release tag '$VERSION_PREFIX$VERSION' has been back-merged into '$DEVELOP_BRANCH'"
-	[ "$commit" = "$BRANCH" ] && echo "- Release branch '$BRANCH' has been merged into '$DEVELOP_BRANCH'"
-
+	if gitflow_has_master_disabled; then
+		if flag push; then
+			echo "- '$DEVELOP_BRANCH' and tags have been pushed to '$ORIGIN'"
+		fi
+	else
+		[ "$commit" = "$MASTER_BRANCH" ] \
+		    && echo "- Master branch '$MASTER_BRANCH' has been back-merged into '$DEVELOP_BRANCH'"
+		[ "$commit" = "$VERSION_PREFIX$VERSION" ] \
+		    && echo "- Release tag '$VERSION_PREFIX$VERSION' has been back-merged into '$DEVELOP_BRANCH'"
+		[ "$commit" = "$BRANCH" ] \
+		    && echo "- Release branch '$BRANCH' has been merged into '$DEVELOP_BRANCH'"
+		if flag push; then
+			echo "- '$DEVELOP_BRANCH', '$MASTER_BRANCH' and tags have been pushed to '$ORIGIN'"
+		fi
+	fi
 	if noflag keep; then
 		keepmsg="'has been deleted"
 		if flag keeplocal; then
@@ -367,10 +390,6 @@ cmd_finish() {
 		keepmsg="is still available"
 	fi
 	echo "- Release branch '$BRANCH' "$keepmsg
-
-	if flag push; then
-		echo "- '$DEVELOP_BRANCH', '$MASTER_BRANCH' and tags have been pushed to '$ORIGIN'"
-	fi
 	echo "- You are now on branch '$(git_current_branch)'"
 	echo
 }
@@ -393,6 +412,13 @@ cmd_branch() {
 	VERSION=$1
 	BRANCH=${2:-$DEVELOP_BRANCH}
 
+	# Handle disabled master
+	if gitflow_has_master_disabled; then
+		UPSTREAM_BRANCH="$DEVELOP_BRANCH"
+	else
+		UPSTREAM_BRANCH="$MASTER_BRANCH"
+	fi
+
 	# Run filter on the version
 	VERSION=$(run_filter_hook branch-finish-version $VERSION)
 
@@ -408,7 +434,8 @@ cmd_branch() {
 		die "Branch '$BRANCH' seems to be a git-flow branch. It's not allowed to release this directly."
 	fi
 
-	if [ "$BRANCH" = "$MASTER_BRANCH" ]; then
+	# Only meanful when master is not disabled
+	if ! gitflow_has_master_disabled && [ "$BRANCH" = "$MASTER_BRANCH" ]; then
 		die "Can not release from the the master branch"
 	fi
 
@@ -424,24 +451,25 @@ cmd_branch() {
 
 	# Update local branches with remote branches
 	if flag fetch; then
-		git_fetch_branch "$ORIGIN" "$MASTER_BRANCH"
+		git_fetch_branch "$ORIGIN" "$UPSTREAM_BRANCH"
 	fi
 
 	# Check if the local branches have all the commits from the remote branches
 	if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
 		require_branches_equal "$BRANCH" "$ORIGIN/$BRANCH"
 	fi
-	if git_remote_branch_exists "$ORIGIN/$MASTER_BRANCH"; then
-		require_branches_equal "$MASTER_BRANCH" "$ORIGIN/$MASTER_BRANCH"
+	# Avoid double check, can only occurs when master is disabled
+	if [ "$BRANCH" != "$UPSTREAM_BRANCH" ] && git_remote_branch_exists "$ORIGIN/$UPSTREAM_BRANCH"; then
+		require_branches_equal "$UPSTREAM_BRANCH" "$ORIGIN/$UPSTREAM_BRANCH"
 	fi
 
 	run_pre_hook "$VERSION_PREFIX$VERSION" "$ORIGIN" "$BRANCH"
 
-	# Try to merge into master.
+	# Try to merge into upstream branch.
 	# In case a previous attempt to finish this release branch has failed,
 	# but the merge into master was successful, we skip it now
-	if ! git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH"; then
-			git checkout "$MASTER_BRANCH" || die "Could not check out branch '$MASTER_BRANCH'."
+	if ! git_is_branch_merged_into "$BRANCH" "$UPSTREAM_BRANCH"; then
+			git checkout "$UPSTREAM_BRANCH" || die "Could not check out branch '$UPSTREAM_BRANCH'."
 			if noflag squash; then
 				git merge --no-ff "$BRANCH" || die "There were merge conflicts." # TODO: What do we do now?
 			else
@@ -470,7 +498,7 @@ cmd_branch() {
 	run_post_hook "$VERSION_PREFIX$VERSION" "$ORIGIN" "$BRANCH"
 
 	if flag push; then
-		git push "$ORIGIN" "$MASTER_BRANCH" || die "Could not push branch '$MASTER_BRANCH' to remote '$ORIGIN'."
+		git push "$ORIGIN" "$UPSTREAM_BRANCH" || die "Could not push branch '$UPSTREAM_BRANCH' to remote '$ORIGIN'."
 		if noflag notag; then
 			git push --tags "$ORIGIN" || die "Could not push tags to remote '$ORIGIN'."
 		fi
@@ -481,13 +509,15 @@ cmd_branch() {
 	if flag fetch; then
 		echo "- Latest objects have been fetched from '$ORIGIN'"
 	fi
-	echo "- Branch '$BRANCH' has been merged into '$MASTER_BRANCH'"
+	if [ "$BRANCH" != "$UPSTREAM_BRANCH" ]; then
+		echo "- Branch '$BRANCH' has been merged into '$UPSTREAM_BRANCH'"
+	fi
 	if noflag notag; then
 		echo "- The release was tagged '$VERSION_PREFIX$VERSION'"
 	fi
 
 	if flag push; then
-		echo "- '$MASTER_BRANCH' and tags have been pushed to '$ORIGIN'"
+		echo "- '$UPSTREAM_BRANCH' and tags have been pushed to '$ORIGIN'"
 	fi
 	echo "- You are now on branch '$(git_current_branch)'"
 	echo
@@ -566,7 +596,8 @@ cmd_delete() {
 		git checkout "$DEVELOP_BRANCH" || die "Could not check out branch '$DEVELOP_BRANCH'."
 	fi
 
-	if ( git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH" && git_is_branch_merged_into "$BRANCH" "$DEVELOP_BRANCH" ); then
+	if ( gitflow_has_master_disabled || git_is_branch_merged_into "$BRANCH" "$MASTER_BRANCH" ) \
+	    && git_is_branch_merged_into "$BRANCH" "$DEVELOP_BRANCH"; then
 		git branch -d "$BRANCH" || die "Could not delete the $BRANCH."
 		if flag remote; then
 			git push "$ORIGIN" :"$BRANCH" || die "Could not delete the remote $BRANCH in $ORIGIN."
@@ -578,11 +609,15 @@ cmd_delete() {
 				git push "$ORIGIN" :"$BRANCH" || die "Could not delete the remote $BRANCH in $ORIGIN."
 			fi
 		else
-			 die "Release branch '$BRANCH' has been not been merged in branch '$MASTER_BRANCH' and/or branch '$DEVELOP_BRANCH'. Use -f to force the deletion."
-		 fi
-	 fi
+			if gitflow_has_master_disabled; then
+			 die "Release branch '$BRANCH' has been not been merged in develop branch '$DEVELOP_BRANCH'. Use -f to force the deletion."
+			else
+			 die "Release branch '$BRANCH' has been not been merged in master '$MASTER_BRANCH' and/or develop branch '$DEVELOP_BRANCH'. Use -f to force the deletion."
+			fi
+		fi
+	fi
 
-	 run_post_hook "$VERSION" "$ORIGIN" "$BRANCH"
+	run_post_hook "$VERSION" "$ORIGIN" "$BRANCH"
 
 	echo
 	echo "Summary of actions:"

--- a/git-flow-support
+++ b/git-flow-support
@@ -59,6 +59,13 @@ cmd_list() {
 	DEFINE_boolean verbose false 'verbose (more) output' v
 	parse_args "$@"
 
+	# Handle disabled master
+	if gitflow_has_master_disabled; then
+		UPSTREAM_BRANCH="$DEVELOP_BRANCH"
+	else
+		UPSTREAM_BRANCH="$MASTER_BRANCH"
+	fi
+
 	local support_branches
 	local current_branch
 	support_branches=$(git_local_branches_prefixed "$PREFIX")
@@ -84,8 +91,8 @@ cmd_list() {
 
 	local branch
 	for branch in $support_branches; do
-		local base=$(git merge-base "$branch" "$MASTER_BRANCH")
-		local master_sha=$(git rev-parse "$MASTER_BRANCH")
+		local base=$(git merge-base "$branch" "$UPSTREAM_BRANCH")
+		local upstream_sha=$(git rev-parse "$UPSTREAM_BRANCH")
 		local branch_sha=$(git rev-parse "$branch")
 		if [ "$branch" = "$current_branch" ]; then
 			printf "* "
@@ -94,7 +101,7 @@ cmd_list() {
 		fi
 		if flag verbose; then
 			printf "%-${width}s" "${branch#$PREFIX}"
-			if [ "$branch_sha" = "$master_sha" ]; then
+			if [ "$branch_sha" = "$upstream_sha" ]; then
 				printf "(no commits yet)"
 			else
 				local tagname=$(git name-rev --tags --no-undefined --name-only "$base")
@@ -138,12 +145,19 @@ cmd_start() {
 	# Sanity checks
 	require_clean_working_tree
 
+	# Handle disabled master
+	if gitflow_has_master_disabled; then
+		UPSTREAM_BRANCH="$DEVELOP_BRANCH"
+	else
+		UPSTREAM_BRANCH="$MASTER_BRANCH"
+	fi
+
 	# Fetch remote changes
 	if flag fetch; then
 		git_fetch_branch "$ORIGIN" "$BASE"
 	fi
 
-	git_is_ancestor "$BASE" "$MASTER_BRANCH" || die "Given base '$BASE' is not a valid commit on '$MASTER_BRANCH'."
+	git_is_ancestor "$BASE" "$UPSTREAM_BRANCH" || die "Given base '$BASE' is not a valid commit on '$UPSTREAM_BRANCH'."
 
 	require_branch_absent "$BRANCH"
 

--- a/gitflow-common
+++ b/gitflow-common
@@ -237,6 +237,10 @@ gitflow_has_master_configured() {
 	[ "$master" != "" ] && git_local_branch_exists "$master"
 }
 
+gitflow_has_master_disabled() {
+	local disabled=$(git config --bool --get gitflow.branch.master.disabled)
+	[ "$disabled" = "true" ]
+}
 gitflow_has_develop_configured() {
 	local develop=$(git config --get gitflow.branch.develop)
 	[ "$develop" != "" ] && git_local_branch_exists "$develop"
@@ -251,10 +255,11 @@ gitflow_has_prefixes_configured() {
 }
 
 gitflow_is_initialized() {
-	gitflow_has_master_configured                    && \
-	gitflow_has_develop_configured                   && \
-	[ "$(git config --get gitflow.branch.master)" != "$(git config --get gitflow.branch.develop)" ] && \
-	gitflow_has_prefixes_configured
+	( gitflow_has_master_disabled || gitflow_has_master_configured ) && \
+	gitflow_has_develop_configured                                   && \
+	gitflow_has_prefixes_configured                                  && \
+	( gitflow_has_master_disabled || \
+	  [ "$(git config --get gitflow.branch.master)" != "$(git config --get gitflow.branch.develop)" ] )
 }
 
 # Loading settings that can be overridden using git config


### PR DESCRIPTION
The production release branch can be marked optional with the new git
configuration

```
git config gitflow.branch.master.disabled true
git flow init -m
git flow init --nomaster
```

The -m/--nomaster option is overridden by the -f/--force one.

If the repository is empty at init time or -f/--force option is passed a
confirmation to disable the production release branch is asked.

The same confirmation is asked if the production release branch name is
the same as the "next release" development branch one.

The user can enable the production release branch by forcing a new
initialization or with plain git configuration.

This is an implementation of #231 to improve my solution to #133.
- gitflow-common (gitflow_has_master_disabled): New helper to check if
  the production release branch is disabled.
  (gitflow_is_initialized): Manage disabled production release branch.
- git-flow-init (usage): add -m flag.
  (cmd_default): Add -m flag.
  Permit to disable the production release branch, either by command line
  option or if the production release branch name is equal to the
  development branch name.
  Permit to enable a separate production release branch when user force
  the initialization.
- git-flow-release: New variable "$UPSTREAM_BRANCH" to avoid lots of call
  to gitflow_has_master_disabled.
  (cmd_finish): Merge to "$UPSTREAM_BRANCH", do not do backmerge and push
  the development branch if the production release branch is disabled.
  (cmd_branch): Merge to "$UPSTREAM_BRANCH".
  (cmd_delete): Check is the release branch is merge in the production
  release branch only if it's not disabled.
- git-flow-hotfix: New variable "$UPSTREAM_BRANCH" to avoid lots of call
  to gitflow_has_master_disabled.
  (cmd_list): Base is on "$UPSTREAM_BRANCH".
  (cmd_finish): Merge to "$UPSTREAM_BRANCH", do not do backmerge and push
  the development branch if the production release branch is disabled.
  (cmd_delete): Check is the release branch is merge in the production
  release branch only if it's not disabled.
- git-flow-support: New variable "$UPSTREAM_BRANCH" to avoid lots of call
  to gitflow_has_master_disabled.
  (cmd_list): Base is on "$UPSTREAM_BRANCH".
  (cmd_start): Ditoo.
