### PR TITLE
Dereference tag when it's meaningful

### DIFF
--- a/gitflow-common
+++ b/gitflow-common
@@ -167,8 +167,8 @@ git_compare_branches() {
 # Checks whether branch $1 is successfully merged into $2
 #
 git_is_branch_merged_into() {
-	local merge_hash=$(git merge-base $1 $2)
-	local base_hash=$(git rev-parse $1)
+	local merge_hash=$(git merge-base "$1"^{} "$2"^{})
+	local base_hash=$(git rev-parse "$1"^{})
 
 	# If the hashes are equal, the branches are merged.
 	[ "$merge_hash" = "$base_hash" ]
@@ -181,8 +181,7 @@ git_is_branch_merged_into() {
 # for readability given a different name.
 #
 git_is_ancestor() {
-	git_tag_exists "$1" && git_is_branch_merged_into "$1"^0 "$2" \
-	    || git_is_branch_merged_into "$1" "$2"
+	git_is_branch_merged_into "$1" "$2"
 }
 
 #


### PR DESCRIPTION
It's an improvement of petervanderdoes/gitflow#11.
- gitflow-common (git_is_branch_merged_into): The notation "^{}"
  dereferences tag refs and does nothing for other ref types.
  (git_is_ancestor): No need to make tags a special case.
