### PR TITLE
Rename git_compare_branches to git_compare_refs and make it tag aware

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -276,7 +276,7 @@ cmd_finish() {
 	# - has commits: No reason to finish a hotfix without commits
 	# - Is ahead of the master: If it's not a good idea to merge
 	# - Can be merged: If there's no common ancestor we can't merge the hotfix
-	git_compare_branches "$BRANCH" "$MASTER_BRANCH"
+	git_compare_refs "$BRANCH" "$MASTER_BRANCH"
 	case $? in
 		0) die "You need some commits in the hotfix branch '$BRANCH'"
 		   ;;

--- a/gitflow-common
+++ b/gitflow-common
@@ -131,20 +131,20 @@ git_tag_exists() {
 }
 
 #
-# git_compare_branches()
+# git_compare_refs()
 #
-# Tests whether branches and their "origin" counterparts have diverged and need
-# merging first. It returns error codes to provide more detail, like so:
+# Tests whether two references have diverged and need merging
+# first. It returns error codes to provide more detail, like so:
 #
-# 0    Branch heads point to the same commit
-# 1    First given branch needs fast-forwarding
-# 2    Second given branch needs fast-forwarding
-# 3    Branch needs a real merge
-# 4    There is no merge base, i.e. the branches have no common ancestors
+# 0    References point to the same commit
+# 1    First given reference needs fast-forwarding
+# 2    Second given referenc needs fast-forwarding
+# 3    References need a real merge
+# 4    There is no merge base, i.e. the references have no common ancestors
 #
-git_compare_branches() {
-	local commit1=$(git rev-parse "$1")
-	local commit2=$(git rev-parse "$2")
+git_compare_refs() {
+	local commit1=$(git rev-parse "$1"^{})
+	local commit2=$(git rev-parse "$2"^{})
 	if [ "$commit1" != "$commit2" ]; then
 		local base=$(git merge-base "$commit1" "$commit2")
 		if [ $? -ne 0 ]; then
@@ -380,7 +380,7 @@ require_tag_absent() {
 require_branches_equal() {
 	require_local_branch "$1"
 	require_remote_branch "$2"
-	git_compare_branches "$1" "$2"
+	git_compare_refs "$1" "$2"
 	local status=$?
 	if [ $status -gt 0 ]; then
 		warn "Branches '$1' and '$2' have diverged."


### PR DESCRIPTION
- gitflow-common (git_compare_refs): New name of git_compare_branches(),
  dereference possible tags passed as arguments.
  (require_branches_equal): Use new name.
- git-flow-hotfix (cmd_finish): Use new name.
