### PR TITLE
Permit to use a single symlink as installation method

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -47,7 +47,7 @@ fi
 
 # The sed expression here replaces all backslashes by forward slashes.
 # This helps our Windows users, while not bothering our Unix users.
-export GITFLOW_DIR=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+export GITFLOW_DIR=$(dirname "$(readlink -e "$0" | sed -e 's,\\,/,g')")
 
 # Extra environment settings
 if [ -f ~/.gitflow_export ]; then


### PR DESCRIPTION
This patch permit to create a link in $PATH pointing to sources.
- git-flow (GITFLOW_DIR): dereference $0 to handle symlink.
