### PR TITLE
Fixing issue: Git refuses to delete local branch if it is tracking a remote one.

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -421,38 +421,32 @@ S,squash       Squash feature during merge
 }
 
 helper_finish_cleanup() {
-	local keepmsg remotebranch removebase
+	local keepmsg remotebranchdeleted localbranchdeleted
 
 	# Sanity checks
 	require_branch "$BRANCH"
 	require_clean_working_tree
 
 	if noflag keep; then
-		removebase=$FLAGS_FALSE
-
-		if noflag keeplocal; then
-			removebase=$FLAGS_TRUE
-			if flag force_delete; then
-				git_do branch -D "$BRANCH"
-			else
-				git_do branch -d "$BRANCH"
-			fi
-		fi
-
-		if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
-			removebase=$FLAGS_FALSE
-		fi
-
+	
+		# Always delete remote first
 		if noflag keepremote;then
-			remotebranch=0
 			if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
-				removebase=$FLAGS_TRUE
-				remotebranch=1
-				git_remote_branch_delete "$BRANCH"
+				git_remote_branch_delete "$BRANCH" && remotebranchdeleted=1
 			fi
 		fi
 
-		if [ $removebase -eq $FLAGS_TRUE ]; then
+		# Delete local after remote to avoid warnings
+		if noflag keeplocal; then
+			if flag force_delete; then
+				git_do branch -D "$BRANCH" && localbranchdeleted=1
+			else
+				git_do branch -d "$BRANCH" && localbranchdeleted=1
+			fi
+		fi
+		
+		# no more branches: we can safely remove config section
+		if ! git_remote_branch_exists "$ORIGIN/$BRANCH" -a ! git_local_branch_exists "$BRANCH"; then
 			gitflow_config_remove_base_section "$BRANCH"
 		fi
 	fi
@@ -462,20 +456,21 @@ helper_finish_cleanup() {
 	echo "- The feature branch '$BRANCH' was merged into '$BASE_BRANCH'"
 	#echo "- Merge conflicts were resolved"		# TODO: Add this line when it's supported
 	if noflag keep; then
-		keepmsg="'has been deleted"
-		if flag keeplocal; then
-			keepmsg="is locally still available."
-			if [ $remotebranch -eq 1 ]; then
-				keepmsg=$keepmsg" It is deleted from '$ORIGIN'."
-			fi
+		if [ $localbranchdeleted -eq 1 ]; then
+			keepmsg="has been locally deleted"
+		else
+			keepmsg="is still locally available"
 		fi
-		if flag keepremote ; then
-			if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
-				keepmsg="is remotely still available. It is deleted locally."
-			fi
+		if [ $remotebranchdeleted -eq 1 ]; then
+			keepmsg=$keepmsg"; it has been remotely deleted from '$ORIGIN'"
+		elif git_remote_branch_exists "$ORIGIN/$BRANCH"; then
+			keepmsg=$keepmsg"; it is still remotely available on '$ORIGIN'"
 		fi
 	else
-		keepmsg="is still available"
+		keepmsg="is still locally available"
+		if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
+			keepmsg=$keepmsg"; it is still remotely available on '$ORIGIN'"
+		fi
 	fi
 	echo "- Feature branch '$BRANCH' "$keepmsg
 	echo "- You are now on branch '$(git_current_branch)'"

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -301,7 +301,7 @@ git flow hotfix finish [-h] [-F] [-s] [-u] [-m | -f ] [-p] [-k] [-n] [-b] <versi
 Finish hotfix branch <version>
 --
 h,help!           Show this help
-showcommands!    Show git commands while executing them
+showcommands!     Show git commands while executing them
 F,fetch           Fetch from origin before performing finish
 s,sign            Sign the release tag cryptographically
 u,signingkey      Use the given GPG-key for the digital signature (implies -s)
@@ -311,10 +311,11 @@ p,push            Push to origin after performing finish
 k,keep            Keep branch after performing finish
 keepremote        Keep the remote branch
 keeplocal         Keep the local branch
+D,force_delete    Force delete hotfix branch after finish
 n,notag           Don't tag this release
 b,nobackmerge     Don't back-merge master, or tag if applicable, in develop
 "
-	local opts commit remotebranch removebase
+	local opts commit keepmsg remotebranchdeleted localbranchdeleted
 
 	# Define flags
 	DEFINE_boolean fetch false "fetch from $ORIGIN before performing finish" F
@@ -326,6 +327,7 @@ b,nobackmerge     Don't back-merge master, or tag if applicable, in develop
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean keepremote false "keep the remote branch"
 	DEFINE_boolean keeplocal false "keep the local branch"
+	DEFINE_boolean force_delete false "force delete hotfix branch after finish" D
 	DEFINE_boolean notag false "don't tag this release" n
 	DEFINE_boolean nobackmerge false "don't back-merge $MASTER_BRANCH, or tag if applicable, in $DEVELOP_BRANCH " b
 
@@ -469,29 +471,28 @@ b,nobackmerge     Don't back-merge master, or tag if applicable, in develop
 
 	# Delete branch
 	if noflag keep; then
-		removebase=$FLAGS_FALSE
 
-		if noflag keeplocal; then
-			removebase=$FLAGS_TRUE
-			git_do branch -d "$BRANCH"
-		fi
-
-		if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
-			removebase=$FLAGS_FALSE
-		fi
-
+		# Always delete remote first
 		if noflag keepremote;then
-			removebase=$FLAGS_TRUE
-			remotebranch=0
 			if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
-				remotebranch=1
-				git_remote_branch_delete "$BRANCH"
+				git_remote_branch_delete "$BRANCH" && remotebranchdeleted=1
 			fi
 		fi
 
-		if [ $removebase -eq $FLAGS_TRUE ]; then
+		# Delete local after remote to avoid warnings
+		if noflag keeplocal; then
+			if flag force_delete; then
+				git_do branch -D "$BRANCH" && localbranchdeleted=1
+			else
+				git_do branch -d "$BRANCH" && localbranchdeleted=1
+			fi
+		fi
+		
+		# no more branches: we can safely remove config section
+		if ! git_remote_branch_exists "$ORIGIN/$BRANCH" -a ! git_local_branch_exists "$BRANCH"; then
 			gitflow_config_remove_base_section "$BRANCH"
 		fi
+		
 	fi
 
 	if flag push; then
@@ -509,7 +510,7 @@ b,nobackmerge     Don't back-merge master, or tag if applicable, in develop
 	if flag fetch; then
 		echo "- Latest objects have been fetched from '$ORIGIN'"
 	fi
-	echo "- Hotfix branch '$BRANCH'has been merged into '$BASE_BRANCH'"
+	echo "- Hotfix branch '$BRANCH' has been merged into '$BASE_BRANCH'"
 	if noflag notag; then
 		echo "- The hotfix was tagged '$VERSION_PREFIX$VERSION'"
 	fi
@@ -519,20 +520,21 @@ b,nobackmerge     Don't back-merge master, or tag if applicable, in develop
 		[ "$commit" = "$BRANCH" ] && echo "- Hotfix branch '$BRANCH' has been merged into '$DEVELOP_BRANCH'"
 	fi
 	if noflag keep; then
-		local keepmsg="'has been deleted"
-		if flag keeplocal; then
-			keepmsg="is locally still available."
-			if [ $remotebranch -eq 1 ]; then
-				keepmsg=$keepmsg" It is deleted from '$ORIGIN'."
-			fi
+		if [ $localbranchdeleted -eq 1 ]; then
+			keepmsg="has been locally deleted"
+		else
+			keepmsg="is still locally available"
 		fi
-		if flag keepremote ; then
-			if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
-				keepmsg="is remotely still available. It is deleted locally."
-			fi
+		if [ $remotebranchdeleted -eq 1 ]; then
+			keepmsg=$keepmsg"; it has been remotely deleted from '$ORIGIN'"
+		elif git_remote_branch_exists "$ORIGIN/$BRANCH"; then
+			keepmsg=$keepmsg"; it is still remotely available on '$ORIGIN'"
 		fi
 	else
-		keepmsg="is still available"
+		keepmsg="is still locally available"
+		if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
+			keepmsg=$keepmsg"; it is still remotely available on '$ORIGIN'"
+		fi
 	fi
 	echo "- Hotfix branch '$BRANCH' "$keepmsg
 	if flag push; then

--- a/git-flow-release
+++ b/git-flow-release
@@ -40,7 +40,7 @@
 # Called when the base of the release is the $DEVELOP_BRANCH
 #
 _finish_from_develop() {
-	local opts merge_branch commit remotebranch keepmsg removebase
+	local opts merge_branch commit keepmsg remotebranchdeleted localbranchdeleted
 
 		# Update local branches with remote branches
 	if flag fetch; then
@@ -138,30 +138,29 @@ _finish_from_develop() {
 
 	# Delete branch
 	if noflag keep; then
-		removebase=$FLAGS_FALSE
 
 		if [ "$BRANCH" = "$(git_current_branch)" ]; then
 			git_do checkout "$MASTER_BRANCH" || die "Could not check out branch '$MASTER_BRANCH'."
 		fi
-		if noflag keeplocal; then
-			removebase=$FLAGS_TRUE
-			git_do branch -d "$BRANCH"
-		fi
 
-		if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
-			removebase=$FLAGS_FALSE
-		fi
-
-		if noflag keepremote; then
-			remotebranch=0
+		# Always delete remote first
+		if noflag keepremote;then
 			if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
-				removebase=$FLAGS_TRUE
-				remotebranch=1
-				git_remote_branch_delete "$BRANCH"
+				git_remote_branch_delete "$BRANCH" && remotebranchdeleted=1
 			fi
 		fi
 
-		if [ $removebase -eq $FLAGS_TRUE ]; then
+		# Delete local after remote to avoid warnings
+		if noflag keeplocal; then
+			if flag force_delete; then
+				git_do branch -D "$BRANCH" && localbranchdeleted=1
+			else
+				git_do branch -d "$BRANCH" && localbranchdeleted=1
+			fi
+		fi
+		
+		# no more branches: we can safely remove config section
+		if ! git_remote_branch_exists "$ORIGIN/$BRANCH" -a ! git_local_branch_exists "$BRANCH"; then
 			gitflow_config_remove_base_section "$BRANCH"
 		fi
 	fi
@@ -188,20 +187,21 @@ _finish_from_develop() {
 	[ "$commit" = "$BRANCH" ] && echo "- Release branch '$BRANCH' has been merged into '$DEVELOP_BRANCH'"
 
 	if noflag keep; then
-		keepmsg="'has been deleted"
-		if flag keeplocal; then
-			local keepmsg="is locally still available."
-			if [ $remotebranch -eq 1 ]; then
-				keepmsg=$keepmsg" It is deleted from '$ORIGIN'."
-			fi
+		if [ $localbranchdeleted -eq 1 ]; then
+			keepmsg="has been locally deleted"
+		else
+			keepmsg="is still locally available"
 		fi
-		if flag keepremote; then
-			if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
-				keepmsg="is remotely still available. It is deleted locally."
-			fi
+		if [ $remotebranchdeleted -eq 1 ]; then
+			keepmsg=$keepmsg"; it has been remotely deleted from '$ORIGIN'"
+		elif git_remote_branch_exists "$ORIGIN/$BRANCH"; then
+			keepmsg=$keepmsg"; it is still remotely available on '$ORIGIN'"
 		fi
 	else
-		keepmsg="is still available"
+		keepmsg="is still locally available"
+		if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
+			keepmsg=$keepmsg"; it is still remotely available on '$ORIGIN'"
+		fi
 	fi
 	echo "- Release branch '$BRANCH' "$keepmsg
 
@@ -218,7 +218,7 @@ _finish_from_develop() {
 #
 
 _finish_base() {
-	local opts merge_branch commit remotebranch keepmsg remove base
+	local opts merge_branch commit keepmsg localbranchdeleted remotebranchdeleted
 
 	# Update local branches with remote branches
 	if flag fetch; then
@@ -291,30 +291,29 @@ _finish_base() {
 
 	# Delete branch
 	if noflag keep; then
-		removebase=$FLAGS_FALSE
 
 		if [ "$BRANCH" = "$(git_current_branch)" ]; then
 			git_do checkout "$BASE_BRANCH" || die "Could not check out branch '$BASE_BRANCH'."
 		fi
-		if noflag keeplocal; then
-			removebase=$FLAGS_TRUE
-			git_do branch -d "$BRANCH"
-		fi
-
-		if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
-			removebase=$FLAGS_FALSE
-		fi
-
-		if noflag keepremote; then
-			removebase=$FLAGS_TRUE
-			remotebranch=0
+		
+		# Always delete remote first
+		if noflag keepremote;then
 			if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
-				remotebranch=1
-				git_remote_branch_delete "$BRANCH"
+				git_remote_branch_delete "$BRANCH" && remotebranchdeleted=1
 			fi
 		fi
 
-		if [ $removebase -eq $FLAGS_TRUE ]; then
+		# Delete local after remote to avoid warnings
+		if noflag keeplocal; then
+			if flag force_delete; then
+				git_do branch -D "$BRANCH" && localbranchdeleted=1
+			else
+				git_do branch -d "$BRANCH" && localbranchdeleted=1
+			fi
+		fi
+		
+		# no more branches: we can safely remove config section
+		if ! git_remote_branch_exists "$ORIGIN/$BRANCH" -a ! git_local_branch_exists "$BRANCH"; then
 			gitflow_config_remove_base_section "$BRANCH"
 		fi
 	fi
@@ -337,20 +336,21 @@ _finish_base() {
 	[ "$commit" = "$VERSION_PREFIX$VERSION" ] && echo "- Release tag '$VERSION_PREFIX$VERSION' has been merged into '$BASE_BRANCH'"
 	[ "$commit" = "$BRANCH" ] && echo "- Release branch '$BRANCH' has been merged into '$BASE_BRANCH'"
 	if noflag keep; then
-		keepmsg="'has been deleted"
-		if flag keeplocal; then
-			local keepmsg="is locally still available."
-			if [ $remotebranch -eq 1 ]; then
-				keepmsg=$keepmsg" It is deleted from '$ORIGIN'."
-			fi
+		if [ $localbranchdeleted -eq 1 ]; then
+			keepmsg="has been locally deleted"
+		else
+			keepmsg="is still locally available"
 		fi
-		if flag keepremote; then
-			if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
-				keepmsg="is remotely still available. It is deleted locally."
-			fi
+		if [ $remotebranchdeleted -eq 1 ]; then
+			keepmsg=$keepmsg"; it has been remotely deleted from '$ORIGIN'"
+		elif git_remote_branch_exists "$ORIGIN/$BRANCH"; then
+			keepmsg=$keepmsg"; it is still remotely available on '$ORIGIN'"
 		fi
 	else
-		keepmsg="is still available"
+		keepmsg="is still locally available"
+		if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
+			keepmsg=$keepmsg"; it is still remotely available on '$ORIGIN'"
+		fi
 	fi
 	echo "- Release branch '$BRANCH' "$keepmsg
 
@@ -554,19 +554,20 @@ git flow release finish [-h] [-F] [-s] [-u] [-m | -f] [-p] [-k] [-n] [-b] [-S] <
 Finish a release branch
 --
 h,help          Show this help
-showcommands!    Show git commands while executing them
-F,fetch 		Fetch from origin before performing finish
+showcommands!   Show git commands while executing them
+F,fetch         Fetch from origin before performing finish
 s,sign!         Sign the release tag cryptographically
-u,signingkey! 	Use the given GPG-key for the digital signature (implies -s)
-m,message! 		Use the given tag message
-f,messagefile= 	Use the contents of the given file as a tag message
-p,push 			Push to origin after performing finish
+u,signingkey!   Use the given GPG-key for the digital signature (implies -s)
+m,message!      Use the given tag message
+f,messagefile=  Use the contents of the given file as a tag message
+p,push          Push to origin after performing finish
 k,keep          Keep branch after performing finish
 keepremote      Keep the remote branchk
-keeplocal 		Keep the local branch
-n,tag 			Don't tag this release
-b,nobackmerge 	Don't back-merge master, or tag if applicable, in develop
-S,squash 		Squash release during merge
+keeplocal       Keep the local branch
+D,force_delete  Force delete release branch after finish
+n,tag           Don't tag this release
+b,nobackmerge   Don't back-merge master, or tag if applicable, in develop
+S,squash        Squash release during merge
 "
 	# Define flags
 	DEFINE_boolean fetch false "fetch from $ORIGIN before performing finish" F
@@ -578,6 +579,7 @@ S,squash 		Squash release during merge
 	DEFINE_boolean keep false "keep branch after performing finish" k
 	DEFINE_boolean keepremote false "keep the remote branch"
 	DEFINE_boolean keeplocal false "keep the local branch"
+	DEFINE_boolean force_delete false "force delete release branch after finish" D
 	DEFINE_boolean notag false "don't tag this release" n
 	DEFINE_boolean nobackmerge false "don't back-merge $MASTER_BRANCH, or tag if applicable, in $DEVELOP_BRANCH " b
 	DEFINE_boolean squash false "squash release during merge" S


### PR DESCRIPTION
Hello,

Im' trying to fix the following issue:

When a feature/release/hotfix is published and then finished, Git would refuse to delete the local branch because it is tracking a remote one. The message is:

> warning: not deleting branch 'hotfix/xxx' that is not yet merged to
> 'refs/remotes/origin/hotfix/xxx', even though it is merged to HEAD.
> error: The branch 'hotfix/xxx' is not fully merged.

Git version is 1.8.0.1.

I fixed the problem by deleting the remote branch _prior_ to deleting the local one.

Additionnally, I brought a small improvement: a new option "force_delete" for releases and hotfixes to force local branch deletion ("-D"), similar to the existing one for features.
