### PR TITLE
Switch to another branch before deleting current release/hotfix local branch

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -438,6 +438,9 @@ helper_finish_cleanup() {
 
 		# Delete local after remote to avoid warnings
 		if noflag keeplocal; then
+			if [ "$BRANCH" = "$(git_current_branch)" ]; then
+				git_do checkout "$BASE_BRANCH" || die "Could not check out branch '$BASE_BRANCH'."
+			fi
 			if flag force_delete; then
 				git_do branch -D "$BRANCH" && localbranchdeleted=1
 			else

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -475,7 +475,7 @@ b,nobackmerge     Don't back-merge master, or tag if applicable, in develop
 
 	# Delete branch
 	if noflag keep; then
-
+	
 		# Always delete remote first
 		if noflag keepremote;then
 			if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
@@ -485,6 +485,9 @@ b,nobackmerge     Don't back-merge master, or tag if applicable, in develop
 
 		# Delete local after remote to avoid warnings
 		if noflag keeplocal; then
+			if [ "$BRANCH" = "$(git_current_branch)" ]; then
+				git_do checkout "$DEVELOP_BRANCH" || die "Could not check out branch '$DEVELOP_BRANCH'."
+			fi
 			if flag force_delete; then
 				git_do branch -D "$BRANCH" && localbranchdeleted=1
 			else

--- a/git-flow-release
+++ b/git-flow-release
@@ -292,10 +292,6 @@ _finish_base() {
 	# Delete branch
 	if noflag keep; then
 
-		if [ "$BRANCH" = "$(git_current_branch)" ]; then
-			git_do checkout "$BASE_BRANCH" || die "Could not check out branch '$BASE_BRANCH'."
-		fi
-		
 		# Always delete remote first
 		if noflag keepremote;then
 			if git_remote_branch_exists "$ORIGIN/$BRANCH"; then
@@ -305,6 +301,9 @@ _finish_base() {
 
 		# Delete local after remote to avoid warnings
 		if noflag keeplocal; then
+			if [ "$BRANCH" = "$(git_current_branch)" ]; then
+				git_do checkout "$BASE_BRANCH" || die "Could not check out branch '$BASE_BRANCH'."
+			fi
 			if flag force_delete; then
 				git_do branch -D "$BRANCH" && localbranchdeleted=1
 			else


### PR DESCRIPTION
Currently for releases and hotfixes, when one tries to delete the current local branch, it sometimes happens that that branch is still the current one (e.g. if the merge back to master/develop already took place in a previous attempt to finish).

In these situations, the local branch cannot be deleted. The error message is:

> error: Cannot delete the branch 'hotfix/xxx' which you are currently on.

One must  checkout another branch before deleting the release/hotfix branch.

The git-flow-feature script already does such a check.
