### PR TITLE
Provide a way to "--showcommands" all the time

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -110,6 +110,9 @@ main() {
 
 	# allow user to request git action logging
 	DEFINE_boolean 'showcommands' false 'Show actions taken (git commands)'
+	# but if the user prefers that the logging is always on,
+	# use the environmental variables.
+	gitflow_override_flag_boolean 'SHOWCOMMANDS' 'showcommands'
 
 	# Sanity checks
 	SUBCOMMAND="$1"; shift


### PR DESCRIPTION
The [configuration page](https://github.com/petervanderdoes/gitflow/wiki/Reference:-Configuration) had me _convinced_ it was possible to leave `--showcommands` on by default. But after combing through hundreds of lines of bash, I discovered that my desired feature was just waiting to be implemented!

A few details:
- If you'd prefer that the environmental variable be named something else, like `$GLOBAL_SHOWCOMMANDS` or `$show_ALL_the_commands`, I'm happy to adjust to that.
- If you'd prefer that the call to `gitflow_override_flag_boolean` occur elsewhere in the git-flow lifecycle (perhaps in gitflow-common's `git_do`?), that's A-OK. I'll move it.
- If this pull request is actually a wrong-headed endeavor and I should have just set up an alias in my gitconfig at the beginning, that's also fine **but** it seems like an example of that should be on the [configuration page](https://github.com/petervanderdoes/gitflow/wiki/Reference:-Configuration) or [FAQ](https://github.com/petervanderdoes/gitflow/wiki/FAQ).
