### PR TITLE
Fix variable non-zero test

### DIFF
--- a/gitflow-common
+++ b/gitflow-common
@@ -481,7 +481,7 @@ gitflow_override_flag_string() {
 
 	_env_var="GITFLOW_FLAG_"$1
 	eval "_variable=\$${_env_var}"
-	if [ -n ${_variable} ]; then
+	if [ -n "${_variable}" ]; then
 		eval "FLAGS_${2}=${_variable}"
 	fi
 	unset _variable _env_var


### PR DESCRIPTION
Due to missing quotation marks, the -n test won't work properly, leading
to (strangely) always returning true and overriding variables with
nothing.

That causes "release finish" and "hotfix finish" to silently ignore the
flags -u, -m, and -f, and perhaps also some others which I didn't try.

With the quotation marks in place now that shouldn't be an issue
anymore.
