### PR TITLE
RFC: Support for automatically generated tag messages

### DIFF
--- a/git-flow-config
+++ b/git-flow-config
@@ -126,6 +126,9 @@ file= use given config file
 	output=$(git config $gitflow_config_option --get gitflow.prefix.versiontag)
 	echo "Version tag prefix: $output "
 
+	output=$(git config $gitflow_config_option --get gitflow.config.autotagmessage)
+	echo "Automatic tag message: $output "
+
 	output=$(git config $gitflow_config_option --get gitflow.config.tagmessage)
 	echo "Custom tag message: $output "
 }
@@ -186,6 +189,10 @@ file= use given config file
 		cfg_option="gitflow.prefix.versiontag"
 		txt="Version tag prefix"
 		;;
+	autotagmessage)
+		cfg_option="gitflow.config.autotagmessage"
+		txt="Automatic tag message"
+		;;
 	tagmessage)
 		cfg_option="gitflow.config.tagmessage"
 		txt="Custom tag message"
@@ -221,6 +228,20 @@ file= use given config file
 		elif ! git_local_branch_exists "$value"; then
 			die "Local branch '$value' does not exist."
 		fi
+	fi
+
+	if [ $OPTION = "autotagmessage" ]; then
+		case $value in
+		true | on | 1)
+			value=true
+			;;
+		false | off | 0)
+			value=false
+			;;
+		*)
+			die "autotagmessage is a boolean option. Set it to true or false."
+			;;
+		esac
 	fi
 
 	git_do config $gitflow_config_option $cfg_option "$value"

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -449,6 +449,9 @@ b,nobackmerge     Don't back-merge master, or tag if applicable, in develop
 				die "Use either -m,--message or -f,--messagefile. Can not use both options at the same time"
 			else 
 				tagmessage=$(git config --get gitflow.config.tagmessage)
+				if [ "$(git config --get gitflow.config.autotagmessage)" = "true" ]; then
+					[ "$tagmessage" = "" ] && tagmessage="$VERSION_PREFIX$VERSION" || die "Both configs autotagmessage and tagmessage are enabled. Please disable either of them."
+				fi
 			fi
 		opts="-a"
 		flag sign && opts="$opts -s"

--- a/git-flow-release
+++ b/git-flow-release
@@ -96,6 +96,9 @@ _finish_from_develop() {
 				die "Use either -m,--message or -f,--messagefile. Can not use both options at the same time"
 			else 
 				tagmessage=$(git config --get gitflow.config.tagmessage)
+				if [ "$(git config --get gitflow.config.autotagmessage)" = "true" ]; then
+					[ "$tagmessage" = "" ] && tagmessage="$VERSION_PREFIX$VERSION" || die "Both configs autotagmessage and tagmessage are enabled. Please disable either of them."
+				fi
 			fi
 			opts="-a"
 			flag sign && opts="$opts -s"
@@ -266,6 +269,9 @@ _finish_base() {
 				die "Use either -m,--message or -f,--messagefile. Can not use both options at the same time"
 			else 
 				tagmessage=$(git config --get gitflow.config.tagmessage)
+				if [ "$(git config --get gitflow.config.autotagmessage)" = "true" ]; then
+					[ "$tagmessage" = "" ] && tagmessage="$VERSION_PREFIX$VERSION" || die "Both configs autotagmessage and tagmessage are enabled. Please disable either of them."
+				fi
 			fi
 			opts="-a"
 			flag sign && opts="$opts -s"
@@ -774,6 +780,9 @@ S,squash 		Squash release during merge
 				die "Use either -m,--message or -f,--messagefile. Can not use both options at the same time"
 			else 
 				tagmessage=$(git config --get gitflow.config.tagmessage)
+				if [ "$(git config --get gitflow.config.autotagmessage)" = "true" ]; then
+					[ "$tagmessage" = "" ] && tagmessage="$VERSION_PREFIX$VERSION" || die "Both configs autotagmessage and tagmessage are enabled. Please disable either of them."
+				fi
 			fi
 			opts="-a"
 			flag sign && opts="$opts -s"


### PR DESCRIPTION
Instead of being prompted to provide a tag message after a hotfix / release finish, why not letting gitflow generate one? With these two new configuration options, one can choose to provide a static message with gitflow.config.tagmessage (for example "Tagging new version"), or letting gitflow create a message based on the current version number by setting gitflow.config.autotagmessage to true. The latter will take the version prefix and the version number to produce the tag message.
