### PR TITLE
Change flags definition order: config first, then CLI arguments

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -221,12 +221,13 @@ F,fetch Fetch from origin before performing local operation
 	# Define flags
 	DEFINE_boolean 'fetch' false 'fetch from origin before performing local operation' F
 
+	# Override defaults with values from config
+	gitflow_override_flag_boolean "FEATURE_START_FETCH" "fetch"
+
 	# Parse arguments
 	parse_args "$@"
 	eval set -- "${FLAGS_ARGV}"
 	base=${2:-$DEVELOP_BRANCH}
-
-	gitflow_override_flag_boolean "FEATURE_START_FETCH" "fetch"
 
 	require_base_is_local_branch "$base"
 	gitflow_require_name_arg
@@ -297,9 +298,7 @@ no-ff!             Never fast-forward during the merge
 	DEFINE_boolean 'squash-info' false "add branch info during squash"
 	DEFINE_boolean 'no-ff!' false "Don't fast-forward ever during merge "
 
-	# Parse arguments
-	parse_args "$@"
-
+	# Override defaults with values from config
 	gitflow_override_flag_boolean "FEATURE_FINISH_FETCH" "fetch"
 	gitflow_override_flag_boolean "FEATURE_FINISH_REBASE" "rebase"
 	gitflow_override_flag_boolean "FEATURE_FINISH_PRESERVE_MERGES" "preserve_merges"
@@ -310,6 +309,9 @@ no-ff!             Never fast-forward during the merge
 	gitflow_override_flag_boolean "FEATURE_FINISH_SQUASH" "squash"
 	gitflow_override_flag_boolean "FEATURE_FINISH_SQUASH_INFO" "squash_info"
 	gitflow_override_flag_boolean "FEATURE_FINISH_NO_FF" "no_ff"
+
+	# Parse arguments
+	parse_args "$@"
 
 	expand_nameprefix_arg_or_current
 
@@ -662,11 +664,12 @@ p,preserve-merges Preserve merges
 	DEFINE_boolean 'interactive' false 'do an interactive rebase' i
 	DEFINE_boolean 'preserve-merges' false 'try to recreate merges' p
 
-	# Parse arguments
-	parse_args "$@"
-
+	# Override defaults with values from config
 	gitflow_override_flag_boolean "FEATURE_REBASE_INTERACTIVE" "interactive"
 	gitflow_override_flag_boolean "FEATURE_REBASE_PRESERVE_MERGES" "preserve_merges"
+
+	# Parse arguments
+	parse_args "$@"
 
 	expand_nameprefix_arg_or_current
 
@@ -781,12 +784,12 @@ r,remote          Delete remote branch
 	DEFINE_boolean 'force' false "force deletion" f
 	DEFINE_boolean 'remote' false "delete remote branch" r
 
-	# Parse arguments
-	parse_args "$@"
-
-	# Check if we need to override the flags
+	# Override defaults with values from config
 	gitflow_override_flag_boolean "FEATURE_DELETE_FORCE" "force"
 	gitflow_override_flag_boolean "FEATURE_DELETE_REMOTE" "remote"
+
+	# Parse arguments
+	parse_args "$@"
 
 	expand_nameprefix_arg
 

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -171,12 +171,13 @@ F,fetch           Fetch from origin before performing local operation
 	# Define flags
 	DEFINE_boolean 'fetch' false "fetch from $ORIGIN before performing finish" F
 
+	# Override defaults with values from config
+	gitflow_override_flag_boolean "HOTFIX_START_FETCH" "fetch"
+
 	# Parse arguments
 	parse_args "$@"
 	eval set -- "${FLAGS_ARGV}"
 	base=${2:-$MASTER_BRANCH}
-
-	gitflow_override_flag_boolean "HOTFIX_START_FETCH" "fetch"
 
 	# No need to continue if not clean
 	require_base_is_local_branch "$base"
@@ -333,9 +334,7 @@ b,nobackmerge     Don't back-merge master, or tag if applicable, in develop
 	DEFINE_boolean 'notag' false "don't tag this hotfix" n
 	DEFINE_boolean 'nobackmerge' false "don't back-merge $MASTER_BRANCH, or tag if applicable, in $DEVELOP_BRANCH " b
 
-	# Parse arguments
-	parse_args "$@"
-
+	# Override defaults with values from config
 	gitflow_override_flag_boolean "HOTFIX_FINISH_FETCH" "fetch"
 	gitflow_override_flag_boolean "HOTFIX_FINISH_SIGN" "sign"
 	gitflow_override_flag_boolean "HOTFIX_FINISH_PUSH" "push"
@@ -349,6 +348,8 @@ b,nobackmerge     Don't back-merge master, or tag if applicable, in develop
 	gitflow_override_flag_string "HOTFIX_FINISH_MESSAGE" "message"
 	gitflow_override_flag_string "HOTFIX_FINISH_MESSAGEFILE" "messagefile"
 
+	# Parse arguments
+	parse_args "$@"
 
 	remotebranchdeleted=$FLAGS_FALSE
 	localbranchdeleted=$FLAGS_FALSE
@@ -596,11 +597,12 @@ r,remote          Delete remote branch
 	DEFINE_boolean 'force' false "force deletion" f
 	DEFINE_boolean 'remote' false "delete remote branch" r
 
-	# Parse arguments
-	parse_args "$@"
-
+	# Override defaults with values from config
 	gitflow_override_flag_boolean "HOTFIX_DELETE_FORCE" "force"
 	gitflow_override_flag_boolean "HOTFIX_FINISH_REMOTE" "remote"
+
+	# Parse arguments
+	parse_args "$@"
 
 	gitflow_require_version_arg
 

--- a/git-flow-init
+++ b/git-flow-init
@@ -82,11 +82,11 @@ file= use given config file
 	DEFINE_boolean 'system' false 'use system config file'
 	DEFINE_string 'file' "" 'use given config file'
 
+	# Override defaults with values from config
+	gitflow_override_flag_boolean "INIT_DEFAULTS" "defaults"
+
 	# Parse arguments
 	parse_args "$@"
-
-	# Check if we need to override the flags
-	gitflow_override_flag_boolean "INIT_DEFAULTS" "defaults"
 
 	if [ "$FLAGS_file" != "" ]; then
 		gitflow_config_option="--file '$FLAGS_file''"

--- a/git-flow-release
+++ b/git-flow-release
@@ -513,12 +513,13 @@ v,verbose! verbose (more) output
 	# Define flags
 	DEFINE_boolean 'fetch' false "fetch from $ORIGIN before performing finish" F
 
+    # Override defaults with values from config
+	gitflow_override_flag_boolean "RELEASE_START_FETCH" "fetch"
+
 	# Parse arguments
 	parse_args "$@"
 	eval set -- "${FLAGS_ARGV}"
 	base=${2:-$DEVELOP_BRANCH}
-
-	gitflow_override_flag_boolean "RELEASE_START_FETCH" "fetch"
 
 	# Run filter on the version
 	VERSION=$(run_filter_hook release-start-version $VERSION)
@@ -603,9 +604,7 @@ S,squash        Squash release during merge
 	DEFINE_boolean 'squash' false "squash release during merge" S
 	DEFINE_boolean 'squash-info' false "add branch info during squash"
 
-	# Parse arguments
-	parse_args "$@"
-
+    # Override defaults with values from config
 	gitflow_override_flag_boolean "RELEASE_FINISH_FETCH" "fetch"
 	gitflow_override_flag_boolean "RELEASE_FINISH_SIGN" "sign"
 	gitflow_override_flag_boolean "RELEASE_FINISH_PUSH" "push"
@@ -620,6 +619,9 @@ S,squash        Squash release during merge
 	gitflow_override_flag_string "RELEASE_FINISH_SIGNINGKEY" "signingkey"
 	gitflow_override_flag_string "RELEASE_FINISH_MESSAGE" "message"
 	gitflow_override_flag_string "RELEASE_FINISH_MESSAGEFILE" "messagefile"
+
+	# Parse arguments
+	parse_args "$@"
 
 	# Run filter on the version
 	VERSION=$(run_filter_hook release-finish-version $VERSION)
@@ -691,10 +693,7 @@ S,squash 		Squash release during merge
 	DEFINE_boolean 'squash' false "squash release during merge" S
 	DEFINE_boolean 'squash-info' false "add branch info during squash"
 
-	# Parse arguments
-	FLAGS "$@" || exit $?
-	eval set -- "${FLAGS_ARGV}"
-
+    # Override defaults with values from config
 	gitflow_override_flag_boolean "RELEASE_BRANCH_FETCH" "fetch"
 	gitflow_override_flag_boolean "RELEASE_BRANCH_SIGN" "sign"
 	gitflow_override_flag_boolean "RELEASE_BRANCH_PUSH" "push"
@@ -704,6 +703,10 @@ S,squash 		Squash release during merge
 	gitflow_override_flag_string "RELEASE_BRANCH_SIGNINGKEY" "signingkey"
 	gitflow_override_flag_string "RELEASE_BRANCH_MESSAGE" "message"
 	gitflow_override_flag_string "RELEASE_BRANCH_MESSAGEFILE" "messagefile"
+
+	# Parse arguments
+	FLAGS "$@" || exit $?
+	eval set -- "${FLAGS_ARGV}"
 
 	# Read arguments into global variables
 	VERSION=$1
@@ -906,11 +909,12 @@ r,remote Delete remote branch
 	DEFINE_boolean 'force' false "force deletion" f
 	DEFINE_boolean 'remote' false "delete remote branch" r
 
-	# Parse arguments
-	parse_args "$@"
-
+    # Override defaults with values from config
 	gitflow_override_flag_boolean "RELEASE_DELETE_FETCH" "fetch"
 	gitflow_override_flag_boolean "RELEASE_DELETE_REMOTE" "remote"
+
+	# Parse arguments
+	parse_args "$@"
 
 	gitflow_require_version_arg
 

--- a/git-flow-support
+++ b/git-flow-support
@@ -160,10 +160,11 @@ F,fetch           Fetch from origin before performing finish
 	# Define flags
 	DEFINE_boolean 'fetch' false "fetch from $ORIGIN before performing finish" F
 
+	# Override defaults with values from config
+	gitflow_override_flag_boolean "SUPPORT_START_FETCH" "fetch"
+
 	# Parse arguments
 	parse_args "$@"
-
-	gitflow_override_flag_boolean "SUPPORT_START_FETCH" "fetch"
 
 	gitflow_require_version_arg
 	gitflow_require_base_arg


### PR DESCRIPTION
This is more convenient way to handle config flags and cli arguments.

In most cases users will put most used configuration variables into the config, and sometimes will overwrite them in CLI call. Currently this behavior is not supported - what is defined in ~/.gitflow_export can't be overwritten manually .
