### PR TITLE
Fix variable assignment

### DIFF
--- a/gitflow-common
+++ b/gitflow-common
@@ -482,7 +482,7 @@ gitflow_override_flag_string() {
 	_env_var="GITFLOW_FLAG_"$1
 	eval "_variable=\$${_env_var}"
 	if [ -n "${_variable}" ]; then
-		eval "FLAGS_${2}=${_variable}"
+		eval "FLAGS_${2}=\"${_variable}\""
 	fi
 	unset _variable _env_var
 	return ${FLAGS_TRUE}


### PR DESCRIPTION
The current implementation of override_flag_string did not allow strings
that contain whitespaces. For example if one sets an environment
variable like so: GITFLOW_FLAG_RELEASE_FINISH_MESSAGE="Tag release",
then a release finish, which calls the override method, would produce an
error, that the command "release" is not found.

So, when the value of the assignment is quoted, there is no problem and
it behaves as expected. (Compare assignment `var=an example` with
`var="an example"`.)
