### PR TITLE
Bug: Hide unnecessary errors from grep

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -108,7 +108,7 @@ main() {
 	# Load common functionality
 	. "$GITFLOW_DIR/gitflow-common"
 
-	if grep -E 'GITFLOW_FLAG_(SHOWCOMMANDS|INIT|FEATURE|HOTFIX|RELEASE|SUPPORT)' ~/.gitflow_export > /dev/null; then
+	if grep -E 'GITFLOW_FLAG_(SHOWCOMMANDS|INIT|FEATURE|HOTFIX|RELEASE|SUPPORT)' ~/.gitflow_export &> /dev/null; then
 		die "Using environment variables for \"showcommands\", \"init\", \"feature\", \"hotfix\", \"release\" and \"support\" in ~/.gitflow_export has deprecated, use git config instead."
 	fi
 


### PR DESCRIPTION
Grep reports an error on stderr if a file does not exist. Since
~/.gitflow_export does not exist on every machine, grep produces errors
on every command. By redirecting stdout as well as stderr to /dev/null
this can be avoided.
