### PR TITLE
Improved installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,9 @@
 
 prefix=/usr/local
 
-datarootdir=$(prefix)/share
-docdir=$(datarootdir)/doc/gitflow
+bindir=$(prefix)/bin
+barebonehooksdir=$(prefix)/share/gitflow/barebone-hooks
+
 # files that need mode 755
 EXEC_FILES=git-flow
 
@@ -53,15 +54,15 @@ all:
 
 install:
 	@test -f gitflow-shFlags || (echo "Run 'git submodule init && git submodule update' first." ; exit 1 )
-	install -d -m 0755 $(prefix)/bin
-	install -d -m 0755 $(docdir)/hooks
-	install -m 0755 $(EXEC_FILES) $(prefix)/bin
-	install -m 0644 $(SCRIPT_FILES) $(prefix)/bin
-	install -m 0644 $(HOOK_FILES) $(docdir)/hooks
+	install -d -m 0755 $(bindir)
+	install -d -m 0755 $(barebonehooksdir)
+	install -m 0755 $(EXEC_FILES) $(bindir)
+	install -m 0644 $(SCRIPT_FILES) $(bindir)
+	install -m 0644 $(HOOK_FILES) $(barebonehooksdir)
 
 uninstall:
-	test -d $(prefix)/bin && \
-	cd $(prefix)/bin && \
+	test -d $(bindir) && \
+	cd $(bindir) && \
 	rm -f $(EXEC_FILES) $(SCRIPT_FILES)
-	test -d $(docdir) && \
-	rm -rf $(docdir)
+	test -d $(barebonehooksdir) && \
+	rm -rf $(barebonehooksdir)


### PR DESCRIPTION
Improved git-flow installer:
* Kept it backward compatible
* Added environment variable REPO_BRANCH_NAME to gitflow-installer.sh to allow installing specific branch
* Example hooks are installed into /usr/local/share/gitflow/barebone-hooks
* gitflow-installer.sh is using temporary directory for git repo instead of the current directory
* Cleanup at the end of installation

**Please do not forget to update the wiki**
* Environment variables that can be used during the installation are not mentioned anywhere.
* https://github.com/petervanderdoes/gitflow/wiki/Reference:-Hooks-and-Filters
