### PR TITLE
Fix for issue #108

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -703,7 +703,7 @@ showcommands!    Show git commands while executing them
 
 	run_pre_hook "$NAME" "$REMOTE" "$BRANCH"
 
-	if git_branch_exists "$BRANCH"; then
+	if git_local_branch_exists "$BRANCH"; then
 		# Again, avoid accidental merges
 		avoid_accidental_cross_branch_action || die
 


### PR DESCRIPTION
git_branch_exists always returns true in this case since the feature branch you're trying to pull out of the remote is indeed going to exist in the remote. The check should be for local branches only.

Adressses issue https://github.com/petervanderdoes/gitflow/issues/108
