### PR TITLE
Version tag prefix no longer empty for git flow init -d.

### DIFF
--- a/git-flow-init
+++ b/git-flow-init
@@ -329,7 +329,7 @@ file=    use given config file
 
 	# Version tag prefix
 	if ! git config --get gitflow.prefix.versiontag >/dev/null 2>&1 || flag force; then
-		default_suggestion=$(git config --get gitflow.prefix.versiontag || echo "")
+		default_suggestion=$(git config --get gitflow.prefix.versiontag || echo "${PWD##*/}-")
 		printf "Version tag prefix? [$default_suggestion] "
 		if noflag defaults; then
 			read answer


### PR DESCRIPTION
When initializing a project with "git flow init -d", the value of
version tag prefix will now be the name of the working folder followed
by a "-".
