### PR TITLE
BUG: Fix wrong variable name in support

### DIFF
--- a/git-flow-support
+++ b/git-flow-support
@@ -139,9 +139,9 @@ parse_args() {
 	eval set -- "${FLAGS_ARGV}"
 
 	# Read arguments into global variables
-	VERSION=$1
+	NAME=$1
 	BASE=$2
-	BRANCH=$PREFIX$VERSION
+	BRANCH=$PREFIX$NAME
 }
 
 cmd_start() {


### PR DESCRIPTION
Since the function gitflow_require_version_arg() tests the variable
$NAME, there is always an error when creating a support branch, because
there the variable $VERSION is used instead.

Obviously support branches are not used quite often, otherwise this error would have been reported much earlier ...
