### PR TITLE
Resolve #148 - Export command fails in 'gitflow_load_settings()'

### DIFF
--- a/gitflow-common
+++ b/gitflow-common
@@ -292,7 +292,7 @@ gitflow_is_initialized() {
 
 # Loading settings that can be overridden using git config
 gitflow_load_settings() {
-	export GIT_CURRENT_REPO_DIR=$(git rev-parse --show-toplevel 2>/dev/null)
+	export GIT_CURRENT_REPO_DIR="$(git rev-parse --show-toplevel 2>/dev/null)"
 	export DOT_GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
 	export HOOKS_DIR=$(git config --get gitflow.path.hooks || echo "$DOT_GIT_DIR"/hooks) # the second option is used to support previous versions of git-flow
 	export MASTER_BRANCH=$(git config --get gitflow.branch.master)


### PR DESCRIPTION
See https://github.com/petervanderdoes/gitflow/issues/148 for a full description
of this issue.  In short, the export can fail (either raising an error from the
shell, or silently exporting an incorrect value) if the path to the repo
contains spaces.

It is solved by quoting the value to be exported, preventing the shell
from splitting the result into multiple values (and then trying to parse those
as multiple variable-names & values).
