### PR TITLE
Fix git_local_branches_prefixed listening

### DIFF
--- a/gitflow-common
+++ b/gitflow-common
@@ -121,7 +121,7 @@ git_all_tags() { git for-each-ref --format='%(refname:short)' refs/tags; }
 
 git_local_branches_prefixed() {
 	[ -z $1 ] && die "Prefix parameter missing." # This should never happen.
-	git for-each-ref --format='%(refname:short)' refs/heads/$1 ;
+	git for-each-ref --format='%(refname:short)' refs/heads/$1\* ;
 }
 
 git_current_branch() {


### PR DESCRIPTION
Wildcarding the for-each-ref will make the function recognize branch prefixes which isn't a subpath. Which  is supported by the original git-flow.

For example default branch prefix for releases is "release/" however I use "release-" which are not recognized when calling `git for-each-ref --format='%(refname:short)' refs/heads/release-`. Adding the wildcard here will detect such branches.
