### PR TITLE
git-flow-log: Remove bashisms

### DIFF
--- a/git-flow-log
+++ b/git-flow-log
@@ -67,7 +67,7 @@ h,help!         Show this help
 showcommands!   Show git commands while executing them
 "
     # Display gitflow's help messages instead
-    if [[ $@ = "--help" || $@ = "-h" ]]; then
+    if [ $@ = "--help" ] || [ $@ = "-h" ]; then
         flags_help
     fi
 
@@ -75,7 +75,7 @@ showcommands!   Show git commands while executing them
     local base=$(gitflow_config_get_base_branch $(git_current_branch))
 
     # no base branch found, comparing against $master
-    if [[ -z $base ]]; then
+    if [ -z $base ]; then
         base=$MASTER_BRANCH
     fi
 


### PR DESCRIPTION
Do not use `[[`, because that is a bashism, and breaks `git flow log` when running under a /bin/sh that is not bash (for example, on Debian). Fixes [Debian #765520](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=765520).

Reported-by: Paul van Tilburg paulvt@debian.org
Signed-off-by: Gergely Nagy algernon@madhouse-project.org
