### PR TITLE
Throw away output from cd command in case CDPATH is being used

### DIFF
--- a/git-flow-init
+++ b/git-flow-init
@@ -343,7 +343,7 @@ file=    use given config file
 	# Paths
 	if ! git config --get gitflow.path.hooks >/dev/null 2>&1 || flag force; then
 		DOT_GIT_DIR=$(git rev-parse --git-dir)
-		DOT_GIT_DIR=$(cd "$DOT_GIT_DIR" && pwd)
+		DOT_GIT_DIR=$(cd "$DOT_GIT_DIR" 2>&1 >/dev/null && pwd)
 		default_suggestion=$(git config --get gitflow.path.hooks || echo "$DOT_GIT_DIR"/hooks)
 		printf "Hooks and filters directory? [$default_suggestion] "
 		if noflag defaults; then

--- a/gitflow-common
+++ b/gitflow-common
@@ -298,7 +298,7 @@ gitflow_is_initialized() {
 gitflow_load_settings() {
 	export GIT_CURRENT_REPO_DIR="$(git rev-parse --show-toplevel 2>/dev/null)"
 	DOT_GIT_DIR=$(git rev-parse --git-dir)
-	export DOT_GIT_DIR=$(cd "$DOT_GIT_DIR" && pwd)
+	export DOT_GIT_DIR=$(cd "$DOT_GIT_DIR" 2>&1 >/dev/null && pwd)
 	export HOOKS_DIR=$(git config --get gitflow.path.hooks || echo "$DOT_GIT_DIR"/hooks) # the second option is used to support previous versions of git-flow
 	export MASTER_BRANCH=$(git config --get gitflow.branch.master)
 	export DEVELOP_BRANCH=$(git config --get gitflow.branch.develop)


### PR DESCRIPTION
In the case of linux systems where CDPATH is being used, it is possible for the cd command to produce output (namely the directory that has been changed to). This causes the DOT_GIT_DIR to end up with two instances of the path in it. The subsequent export fails and I am unable to use git flow.
