### PR TITLE
Checkout the $BRANCH instead of $BASE_BRANCH before tagging

### DIFF
--- a/git-flow-release
+++ b/git-flow-release
@@ -260,7 +260,7 @@ _finish_base() {
 
 	run_pre_hook "$VERSION_PREFIX$VERSION" "$ORIGIN" "$BRANCH"
 
-	git_do checkout "$BASE_BRANCH" || die "Could not check out branch '$BASE_BRANCH'."
+	git_do checkout "$BRANCH" || die "Could not check out branch '$BRANCH'."
 
 	if noflag notag; then
 		# Try to tag the release.


### PR DESCRIPTION
We were trying to use support branches and found that we could not finish a release branch based on a support branch.

We would get errors like

```
C:\Users\egger\Workspace\GitVersionTest [release/1.1]> git flow release finish 1.1
Switched to branch 'support/1.0'
Already on 'support/1.0'
Already up-to-date.
error: The branch 'release/1.1' is not fully merged.
If you are sure you want to delete it, run 'git branch -D release/1.1'.
```

Not only that but when we looked at the repo we found that the $BASE_BRANCH was being tagged instead of the release branch. Looking into the code it became obvious that the error was at the changed lines. Instead of checking out the $BRANCH before tagging the code checked out the $BASE_BRANCH.

With the fix implemented the release finishing goes like

```

C:\Users\egger\Workspace\GitVersionTest [support/1.0]> git flow support start 1.0 master
Switched to a new branch 'support/1.0'

Summary of actions:
- A new branch 'support/1.0' was created, based on 'master'
- You are now on branch 'support/1.0'

C:\Users\egger\Workspace\GitVersionTest [support/1.0]> git flow release start 1.2 support/1.0
Switched to a new branch 'release/1.2'

Summary of actions:
- A new branch 'release/1.2' was created, based on 'support/1.0'
- You are now on branch 'release/1.2'

Follow-up actions:
- Bump the version number now!
- Start committing last-minute fixes in preparing your release
- When done, run:

     git flow release finish '1.2'

C:\Users\egger\Workspace\GitVersionTest [release/1.2]> git commit --allow-empty -m "c"
[release/1.2 e6acc60] c
C:\Users\egger\Workspace\GitVersionTest [release/1.2]> git flow release finish 1.2
Already on 'release/1.2'
Switched to branch 'support/1.0'
Already up-to-date!
Merge made by the 'recursive' strategy.
Deleted branch release/1.2 (was e6acc60).

Summary of actions:
- The release was tagged '1.2'
- Release tag '1.2' has been merged into 'support/1.0'
- Release branch 'release/1.2' has been locally deleted
- You are now on branch 'support/1.0'

C:\Users\egger\Workspace\GitVersionTest [support/1.0]>
```

