### PR TITLE
Remove dashes from DEFINE_boolean names

### DIFF
--- a/git-flow-feature
+++ b/git-flow-feature
@@ -254,13 +254,13 @@ no-ff!                 Never fast-forward during the merge
 	# Define flags
 	DEFINE_boolean 'fetch' false "fetch from $ORIGIN before performing finish" F
 	DEFINE_boolean 'rebase' false "rebase before merging" r
-	DEFINE_boolean 'preserve-merges' false 'try to recreate merges while rebasing' p
+	DEFINE_boolean 'preserve_merges' false 'try to recreate merges while rebasing' p
 	DEFINE_boolean 'keep' false "keep branch after performing finish" k
 	DEFINE_boolean 'keepremote' false "keep the remote branch"
 	DEFINE_boolean 'keeplocal' false "keep the local branch"
 	DEFINE_boolean 'force_delete' false "force delete feature branch after finish" D
 	DEFINE_boolean 'squash' false "squash feature during merge" S
-	DEFINE_boolean 'squash-info' false "add branch info during squash"
+	DEFINE_boolean 'squash_info' false "add branch info during squash"
 	DEFINE_boolean 'no-ff!' false "Don't fast-forward ever during merge "
 
 	# Override defaults with values from config

--- a/git-flow-release
+++ b/git-flow-release
@@ -613,7 +613,7 @@ S,[no]squash        Squash release during merge
 	DEFINE_boolean 'notag' false "don't tag this release" n
 	DEFINE_boolean 'nobackmerge' false "don't back-merge $MASTER_BRANCH, or tag if applicable, in $DEVELOP_BRANCH " b
 	DEFINE_boolean 'squash' false "squash release during merge" S
-	DEFINE_boolean 'squash-info' false "add branch info during squash"
+	DEFINE_boolean 'squash_info' false "add branch info during squash"
 
 	# Override defaults with values from config
 	gitflow_override_flag_boolean   "release.finish.fetch"          "fetch"
@@ -709,7 +709,7 @@ S,[no]squash 		Squash release during merge
 	DEFINE_boolean 'push' false "push to $ORIGIN after performing finish" p
 	DEFINE_boolean 'notag' false "don't tag this release" n
 	DEFINE_boolean 'squash' false "squash release during merge" S
-	DEFINE_boolean 'squash-info' false "add branch info during squash"
+	DEFINE_boolean 'squash_info' false "add branch info during squash"
 
 	# Override defaults with values from config
 	gitflow_override_flag_boolean   "release.branch.fetch"         "fetch"


### PR DESCRIPTION
This fixes the error I was getting when using `release finish`

```
jelte@Jdeapad ~/work/nexus $ git flow release finish v2.1.10.0
/usr/share/misc/shflags: line 315: FLAGS_squash-info=1: command not found
/usr/share/misc/shflags: line 316: __flags_squash-info_type=1: command not found
/usr/share/misc/shflags: line 318: __flags_squash-info_default=1: command not found
/usr/share/misc/shflags: line 319: __flags_squash-info_help=add branch info during squash: command not found
/usr/share/misc/shflags: line 320: __flags_squash-info_short=~: command not found
/usr/share/misc/shflags: line 362: [: info_type:-: integer expression expected
/usr/share/misc/shflags: line 370: [: info_type:-: integer expression expected
```

Shflags uses the name after DEFINE_boolean in a variable name, and variable names cannot contain dashes.