### PR TITLE
Change action order when calling hotfix start

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -227,8 +227,8 @@ F,[no]fetch       Fetch from origin before performing local operation
 	echo "- You are now on branch '$(git_current_branch)'"
 	echo
 	echo "Follow-up actions:"
-	echo "- Bump the version number now!"
 	echo "- Start committing your hot fixes"
+	echo "- Bump the version number now!"
 	echo "- When done, run:"
 	echo
 	echo "     git flow hotfix finish '$VERSION'"


### PR DESCRIPTION
It is more logical to bump the version number after the hotfixes, since there are actual changes that have been done at that point.