### PR TITLE
enhance git-flow diff

### DIFF
--- a/git-flow-bugfix
+++ b/git-flow-bugfix
@@ -589,7 +589,7 @@ showcommands!    Show git commands while executing them
 	base=$(gitflow_config_get_base_branch $BRANCH)
 	base=${base:-$DEVELOP_BRANCH}
 
-	git_do diff "$base..$BRANCH"
+	git_do diff "$base...$BRANCH"
 }
 
 cmd_checkout() {

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -589,7 +589,7 @@ showcommands!    Show git commands while executing them
 	base=$(gitflow_config_get_base_branch $BRANCH)
 	base=${base:-$DEVELOP_BRANCH}
 
-	git_do diff "$base..$BRANCH"
+	git_do diff "$base...$BRANCH"
 }
 
 cmd_checkout() {


### PR DESCRIPTION
Make cmd_diff diff between the lastest commit on a specific branch and the common ancestor with its base.
This enhancement let you review your commits more easier on figuring out what this feature/bugfix added exactly.
The old one exist a proble that after feature2 or bugfix2 are finished, `git flow diff` diff the latest commit on develop branch.
