### PR TITLE
Fix infinite loop during link resolving in Darwin

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -55,7 +55,7 @@ FreeBSD|OpenBSD|NetBSD)
 Darwin)
 	PRG="$0"
 	while [ -h "$PRG" ]; do
-		link=$(readlink "$0")
+		link=$(readlink "$PRG")
 		if expr "$link" : '/.*' > /dev/null; then
 			PRG="$link"
 		else


### PR DESCRIPTION
Fix a bug where link resolving in Darwin might cause an infinite loop in case the link is more than one level deep. This was caused by `$0` being used to recursively resolving link instead of `$PRG` that point to the resolved result. The bug could be reproduced by:

1. Be on Darwin (Mac OS X)
2. `ln -s git-flow git-flow-1`
3. `ln -s git-flow-1 git-flow-2`
4. `env DEBUG=yes ./git-flow-2`

This pull request simply fixes this by replacing `$0` with `$PRG`.