### PR TITLE
Automate Pre-Commit hook install if it exists on git-flow hooks directory

### DIFF
--- a/git-flow-init
+++ b/git-flow-init
@@ -374,6 +374,17 @@ file=    use given config file
 		git_do config $gitflow_config_option gitflow.path.hooks "$hooks_dir"
 	fi
 
+    # Automate Pre-Commit hook install if it exists on git-flow hooks directory
+    hooks_dir=$(git config --get gitflow.path.hooks)
+    if [ -f "$hooks_dir/pre-commit" ]; then
+        # Check whether there's a previous local pre-commit hook 
+        if [ -f "./.git/hooks/pre-commit" ]; then
+            echo "A backup of your local pre-commit hook will be created."
+        fi
+        ln -s "$hooks_dir/pre-commit" -t "./.git/hooks" --backup
+    fi
+
+
 	# TODO: what to do with origin?
 }
 


### PR DESCRIPTION
Hi,
First of all thanks for your great work.

Because `pre-commit` hook is valuable to run a bunch of testing and validation tools before committing, I don't want anyone from my team to miss it when configuring our set of hooks. To avoid an extra activation step ([example](https://github.com/jaspernbrouwer/git-flow-hooks#prevention-hooks)) I did implement it on `git-flow-init` which will check for a `$hooks_dir/pre-commit` file and link it locally (if a local version already exists a backup is created).

I was wondering whether this could be interesting to include on your repository.
If you do agree, later I can detail this feature on the [Installation Instructions](https://github.com/petervanderdoes/gitflow/wiki/Installation) wiki page.

Regards,
Paulo A. Silva