### PR TITLE
Enable pinned version installation

### DIFF
--- a/contrib/gitflow-installer.sh
+++ b/contrib/gitflow-installer.sh
@@ -87,6 +87,11 @@ install)
 		git checkout develop
 		cd "$OLDPWD"
 		;;
+	develop)
+		cd "$REPO_NAME"
+		git checkout tags/$3
+		cd "$OLDPWD"
+		;;		
 	*)
 		usage
 		exit

--- a/contrib/gitflow-installer.sh
+++ b/contrib/gitflow-installer.sh
@@ -87,7 +87,7 @@ install)
 		git checkout develop
 		cd "$OLDPWD"
 		;;
-	develop)
+	version)
 		cd "$REPO_NAME"
 		git checkout tags/$3
 		cd "$OLDPWD"


### PR DESCRIPTION
I would like to pin the git flow version in a installation script, so I added an option to the installer.
