### PR TITLE
Enable install version

### DIFF
--- a/contrib/gitflow-installer.sh
+++ b/contrib/gitflow-installer.sh
@@ -87,6 +87,11 @@ install)
 		git checkout develop
 		cd "$OLDPWD"
 		;;
+	version)
+		cd "$REPO_NAME"
+		git checkout tags/$3
+		cd "$OLDPWD"
+		;;		
 	*)
 		usage
 		exit

--- a/contrib/gitflow-installer.sh
+++ b/contrib/gitflow-installer.sh
@@ -10,7 +10,7 @@
 # Updated for the fork at petervanderdoes
 
 usage() {
-	echo "Usage: [environment] gitflow-installer.sh [install|uninstall] [stable|develop]"
+	echo "Usage: [environment] gitflow-installer.sh [install|uninstall] [stable|develop|version] [tag]"
 	echo "Environment:"
 	echo "   PREFIX=$PREFIX"
 	echo "   REPO_HOME=$REPO_HOME"


### PR DESCRIPTION
Enable install script to fetch a specified version.
Requirement for this change was to be able to pin a version in automated server setup.

For Documentation it should be noted, that it's recommended to download the installer of the same version one wants to install:
wget --no-check-certificate -q -O - https://raw.githubusercontent.com/petervanderdoes/gitflow-avh/1.10.1/contrib/gitflow-installer.sh install version 1.10.1| sudo bash

What do you think?