### PR TITLE
Also use core.hooksPath for suggestion

### DIFF
--- a/git-flow-init
+++ b/git-flow-init
@@ -363,7 +363,7 @@ file=    use given config file
 	if ! git config --get gitflow.path.hooks >/dev/null 2>&1 || flag force; then
 		DOT_GIT_DIR=$(git rev-parse --git-dir)
 		DOT_GIT_DIR=$(cd "$DOT_GIT_DIR" >/dev/null 2>&1 && pwd)
-		default_suggestion=$(git config --get gitflow.path.hooks || echo "$DOT_GIT_DIR"/hooks)
+		default_suggestion=$(git config --get gitflow.path.hooks || git config --get core.hooksPath || echo "$DOT_GIT_DIR"/hooks)
 		printf "Hooks and filters directory? [$default_suggestion] "
 		if noflag defaults; then
 			read answer


### PR DESCRIPTION
On newer git version it is possible to have a custom hook path, so if it's already configured it will be showed as suggestion during gitflow initialization.
Tested with relative path to a folder inside the same repository on which "git flow init" is called.