### PR TITLE
Remove inconsistent case when pre_hook fails

### DIFF
--- a/git-flow-bugfix
+++ b/git-flow-bugfix
@@ -197,7 +197,6 @@ F,[no]fetch      Fetch from origin before performing local operation
 
 	require_base_is_local_branch "$base"
 	gitflow_require_name_arg
-	gitflow_config_set_base_branch $base $BRANCH
 
 	# Update the local repo with remote changes, if asked
 	if flag fetch; then
@@ -215,6 +214,7 @@ F,[no]fetch      Fetch from origin before performing local operation
 
 	run_pre_hook "$NAME" "$ORIGIN" "$BRANCH" "$base"
 
+	gitflow_config_set_base_branch $base $BRANCH
 
 	# create branch
 	git_do checkout -b "$BRANCH" "$base" || die "Could not create bugfix branch '$BRANCH'."

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -198,7 +198,6 @@ F,[no]fetch      Fetch from origin before performing local operation
 
 	require_base_is_local_branch "$base"
 	gitflow_require_name_arg
-	gitflow_config_set_base_branch $base $BRANCH
 
 	# Update the local repo with remote changes, if asked
 	if flag fetch; then
@@ -216,6 +215,7 @@ F,[no]fetch      Fetch from origin before performing local operation
 
 	run_pre_hook "$NAME" "$ORIGIN" "$BRANCH" "$base"
 
+	gitflow_config_set_base_branch $base $BRANCH
 
 	# create branch
 	git_do checkout -b "$BRANCH" "$base" || die "Could not create feature branch '$BRANCH'."

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -187,7 +187,6 @@ F,[no]fetch       Fetch from origin before performing local operation
 	# No need to continue if not clean
 	require_base_is_local_branch "$base"
 	require_clean_working_tree
-	gitflow_config_set_base_branch $base $BRANCH
 
 	# Update the local repo with remote changes, if asked
 	if flag fetch; then
@@ -217,6 +216,8 @@ F,[no]fetch       Fetch from origin before performing local operation
 
 	run_pre_hook "$VERSION_PREFIX$VERSION" "$ORIGIN" "$BRANCH" "$base"
 
+	gitflow_config_set_base_branch $base $BRANCH
+	
 	# Create branch
 	git_do checkout -b "$BRANCH" "$base"  || die "Could not create hotfix branch '$BRANCH'."
 

--- a/git-flow-release
+++ b/git-flow-release
@@ -560,7 +560,6 @@ v,verbose!           Verbose (more) output
 
 	require_base_is_local_branch "$base"
 	gitflow_require_version_arg
-	gitflow_config_set_base_branch $base $BRANCH
 
 	require_no_existing_release_branches
 
@@ -576,6 +575,8 @@ v,verbose!           Verbose (more) output
 	fi
 
 	run_pre_hook "$VERSION_PREFIX$VERSION" "$ORIGIN" "$BRANCH" "$base"
+	
+	gitflow_config_set_base_branch $base $BRANCH
 
 	# Create branch
 	git_do checkout -b "$BRANCH" "$base" || die "Could not create release branch '$BRANCH'."


### PR DESCRIPTION
Moved `gitflow_config_set_base_branch` after `run_pre_hook` to avoid inconsistent state if `pre_hook` fails.

Without these chagens, in case of `pre_hook` failing case, the config file contains the information of a branch that was not created. 
Furthermore, you cannot create the same branch again because the name exists inside config file.

Thank you!