### PR TITLE
Implement --nodevelopmerge. #313 

### DIFF
--- a/git-flow-release
+++ b/git-flow-release
@@ -143,29 +143,31 @@ _finish_from_develop() {
 		merge_branch="$BRANCH"
 	fi
 
-	# Try to merge into develop.
+	# Try to merge into develop unless 'nodevelopmerge' has been specified.
 	# In case a previous attempt to finish this release branch has failed,
 	# but the merge into develop was successful, we skip it now
-	if ! git_is_branch_merged_into "$merge_branch" "$DEVELOP_BRANCH"; then
-		git_do checkout "$DEVELOP_BRANCH" || die "Could not check out branch '$DEVELOP_BRANCH'."
+	if noflag nodevelopmerge; then
+		if ! git_is_branch_merged_into "$merge_branch" "$DEVELOP_BRANCH"; then
+			git_do checkout "$DEVELOP_BRANCH" || die "Could not check out branch '$DEVELOP_BRANCH'."
 
-		if noflag nobackmerge; then
-			# Accounting for 'git describe', if a release is tagged
-			# we use the tag commit instead of the branch.
-			if noflag notag; then
-				commit="$VERSION_PREFIX$TAGNAME"
-			else
-				commit="$MASTER_BRANCH"
-			fi
-			git_do merge --no-ff "$commit" || die "There were merge conflicts." # TODO: What do we do now?
-		else
-			commit="$BRANCH"
-			if noflag squash; then
+			if noflag nobackmerge; then
+				# Accounting for 'git describe', if a release is tagged
+				# we use the tag commit instead of the branch.
+				if noflag notag; then
+					commit="$VERSION_PREFIX$TAGNAME"
+				else
+					commit="$MASTER_BRANCH"
+				fi
 				git_do merge --no-ff "$commit" || die "There were merge conflicts." # TODO: What do we do now?
 			else
-				git_do merge --squash "$commit" || die "There were merge conflicts." # TODO: What do we do now?
-				flag squash_info && gitflow_create_squash_message "Merged release branch '$BRANCH'" "$DEVELOP_BRANCH" "$BRANCH" > "$DOT_GIT_DIR/SQUASH_MSG"
-				git_do commit
+				commit="$BRANCH"
+				if noflag squash; then
+					git_do merge --no-ff "$commit" || die "There were merge conflicts." # TODO: What do we do now?
+				else
+					git_do merge --squash "$commit" || die "There were merge conflicts." # TODO: What do we do now?
+					flag squash_info && gitflow_create_squash_message "Merged release branch '$BRANCH'" "$DEVELOP_BRANCH" "$BRANCH" > "$DOT_GIT_DIR/SQUASH_MSG"
+					git_do commit
+				fi
 			fi
 		fi
 	fi
@@ -625,6 +627,7 @@ b,[no]nobackmerge   Don't back-merge master, or tag if applicable, in develop
 S,[no]squash        Squash release during merge
 [no]ff-master       Fast forward master branch if possible
 T,tagname!          Use given tag name
+[no]nodevelopmerge  Don't back-merge develop branch
 "
 	# Define flags
 	DEFINE_boolean 'fetch' false "fetch from $ORIGIN before performing finish" F
@@ -646,6 +649,7 @@ T,tagname!          Use given tag name
 	DEFINE_boolean 'squash-info' false "add branch info during squash"
 	DEFINE_boolean 'ff-master' false "fast forward master branch if possible"
 	DEFINE_string  'tagname' "" "use the given tag name" T
+	DEFINE_boolean 'nodevelopmerge' false "don't merge $BRANCH into $DEVELOP_BRANCH "
 
 	# Override defaults with values from config
 	gitflow_override_flag_boolean   "release.finish.fetch"          "fetch"
@@ -666,6 +670,7 @@ T,tagname!          Use given tag name
 	gitflow_override_flag_string    "release.finish.signingkey"     "signingkey"
 	gitflow_override_flag_string    "release.finish.message"        "message"
 	gitflow_override_flag_string    "release.finish.messagefile"    "messagefile"
+	gitflow_override_flag_boolean   "release.finish.nodevelopmerge" "nodevelopmerge"
 
 	# Parse arguments
 	parse_args "$@"


### PR DESCRIPTION
Implements the `--nodevelopmerge` flag to `release finish` to disable back-merge into the **develop** branch. The back-merge to **master** is _not_ affected by this flag.
