### PR TITLE
Fix "[: -eq: unexpected operator" message

### DIFF
--- a/gitflow-shFlags
+++ b/gitflow-shFlags
@@ -915,7 +915,8 @@ _flags_parseGetopt()
   done
 
   unset _flags_arg_ _flags_len_ _flags_name_ _flags_opt_ _flags_pos_ \
-	  _flags_strToEval_ _flags_type_ _flags_usName_ _flags_val_
+	  _flags_strToEval_ _flags_type_ _flags_usName_ _flags_val_ \
+	  _flags_argc_
   return ${flags_return}
 }
 

--- a/gitflow-shFlags
+++ b/gitflow-shFlags
@@ -302,6 +302,7 @@ _flags_define()
   # if/then/else contains just a ':' which does nothing. a binary reversal via
   # '!' is not done because it does not work on all shells.
   if [ ${_flags_return_} -eq ${FLAGS_TRUE} ]; then
+	_flags_isNegate_=${FLAGS_FALSE}
 	case ${_flags_type_} in
 	  ${__FLAGS_TYPE_BOOLEAN})
 		if _flags_validBool "${_flags_default_}"; then
@@ -381,7 +382,7 @@ _flags_define()
 
   flags_return=${_flags_return_}
   unset _flags_default_ _flags_help_ _flags_name_ _flags_return_ \
-	  _flags_short_ _flags_type_ _flags_usName_
+	  _flags_short_ _flags_type_ _flags_usName_ _flags_isNegate_
   [ ${flags_return} -eq ${FLAGS_ERROR} ] && _flags_error "${flags_error}"
   return ${flags_return}
 }


### PR DESCRIPTION
If the first DEFINE is not DEFINE_boolean the shell prints an error message.
Using the example in the header of gitflow-shFlags:

./hello.sh: 359: [: -eq: unexpected operator
Hello, world.

This is triggered by

       if [ ${_flags_type_} -eq ${__FLAGS_TYPE_BOOLEAN} \
          -a  ${_flags_isNegate_} -eq ${FLAGS_TRUE} ]; then

where `_flags_isNegate_` is not set and hence the shell reads `-a -eq 0`

This is masked because by the first DEFINE_boolean because `_flags_define`
does not unset the internal variable `_flags_isNegate_` at the end and hence
the value spills over to the next invocation.

Currently all commands seems to define a boolean option first, so strictly
speaking gitflow is not affected.

Signed-off-by: Andreas Heiduk <asheiduk@gmail.com>