### PR TITLE
Master

### DIFF
--- a/git-flow-config
+++ b/git-flow-config
@@ -64,7 +64,7 @@ parse_args() {
 	OPTION=$(echo $1|tr '[:upper:]' '[:lower:]')
 
 	if [ "$FLAGS_file" != "" ]; then
-		gitflow_config_option="--file '$FLAGS_file'"
+		gitflow_config_option="--file $FLAGS_file"
 	elif flag local; then
 		gitflow_config_option="--local"
 	elif flag global; then


### PR DESCRIPTION
Fix naming custom config file
When u run `git flow config set --file .gitflow develop dev` created not `./.gitflow` but `./'.gitflow'`