### PR TITLE
Perform git push before deleting branch

### DIFF
--- a/git-flow-bugfix
+++ b/git-flow-bugfix
@@ -438,6 +438,10 @@ helper_finish_cleanup() {
 	remotebranchdeleted=$FLAGS_FALSE
 	localbranchdeleted=$FLAGS_FALSE
 
+	if flag push; then
+		git_do push "$ORIGIN" "$BASE_BRANCH" || die "Could not push branch '$BASE_BRANCH' to remote '$ORIGIN'."
+	fi
+
 	if noflag keep; then
 
 		# Always delete remote first
@@ -467,10 +471,6 @@ helper_finish_cleanup() {
 		if ! git_remote_branch_exists "$ORIGIN/$BRANCH" -a ! git_local_branch_exists "$BRANCH"; then
 			gitflow_config_remove_base_section "$BRANCH"
 		fi
-	fi
-
-	if flag push; then
-		git_do push "$ORIGIN" "$BASE_BRANCH" || die "Could not push branch '$BASE_BRANCH' to remote '$ORIGIN'."
 	fi
 
 	echo

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -435,12 +435,12 @@ helper_finish_cleanup() {
 	require_branch "$BRANCH"
 	require_clean_working_tree
 
+	remotebranchdeleted=$FLAGS_FALSE
+	localbranchdeleted=$FLAGS_FALSE
+
 	if flag push; then
 		git_do push "$ORIGIN" "$BASE_BRANCH" || die "Could not push branch '$BASE_BRANCH' to remote '$ORIGIN'."
 	fi
-
-	remotebranchdeleted=$FLAGS_FALSE
-	localbranchdeleted=$FLAGS_FALSE
 
 	if noflag keep; then
 

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -435,6 +435,10 @@ helper_finish_cleanup() {
 	require_branch "$BRANCH"
 	require_clean_working_tree
 
+	if flag push; then
+		git_do push "$ORIGIN" "$BASE_BRANCH" || die "Could not push branch '$BASE_BRANCH' to remote '$ORIGIN'."
+	fi
+
 	remotebranchdeleted=$FLAGS_FALSE
 	localbranchdeleted=$FLAGS_FALSE
 
@@ -467,10 +471,6 @@ helper_finish_cleanup() {
 		if ! git_remote_branch_exists "$ORIGIN/$BRANCH" -a ! git_local_branch_exists "$BRANCH"; then
 			gitflow_config_remove_base_section "$BRANCH"
 		fi
-	fi
-
-	if flag push; then
-		git_do push "$ORIGIN" "$BASE_BRANCH" || die "Could not push branch '$BASE_BRANCH' to remote '$ORIGIN'."
 	fi
 
 	echo

--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -582,6 +582,16 @@ T,tagname!            Use given tag name
 
 	run_post_hook "$VERSION_PREFIX$TAGNAME" "$ORIGIN" "$BRANCH"
 
+	if flag push; then
+		if [ "$BASE_BRANCH" = "$MASTER_BRANCH" ]; then
+			git_do push "$ORIGIN" "$DEVELOP_BRANCH" || die "Could not push branch '$DEVELOP_BRANCH' to remote '$ORIGIN'."
+		fi
+		git_do push "$ORIGIN" "$BASE_BRANCH" || die "Could not push branch '$BASE_BRANCH' to remote '$ORIGIN'."
+		if noflag notag; then
+			git_do push --tags "$ORIGIN" || die "Could not push tags to remote '$ORIGIN'."
+		fi
+	fi
+
 	# Delete branch
 	if noflag keep; then
 
@@ -609,16 +619,6 @@ T,tagname!            Use given tag name
 			gitflow_config_remove_base_section "$BRANCH"
 		fi
 
-	fi
-
-	if flag push; then
-		if [ "$BASE_BRANCH" = "$MASTER_BRANCH" ]; then
-			git_do push "$ORIGIN" "$DEVELOP_BRANCH" || die "Could not push branch '$DEVELOP_BRANCH' to remote '$ORIGIN'."
-		fi
-		git_do push "$ORIGIN" "$BASE_BRANCH" || die "Could not push branch '$BASE_BRANCH' to remote '$ORIGIN'."
-		if noflag notag; then
-			git_do push --tags "$ORIGIN" || die "Could not push tags to remote '$ORIGIN'."
-		fi
 	fi
 
 	echo

--- a/git-flow-release
+++ b/git-flow-release
@@ -174,6 +174,18 @@ _finish_from_develop() {
 
 	run_post_hook "$VERSION_PREFIX$TAGNAME" "$ORIGIN" "$BRANCH"
 
+	if flag push; then
+		if flag pushdevelop; then
+			git_do push "$ORIGIN" "$DEVELOP_BRANCH" || die "Could not push branch '$DEVELOP_BRANCH' to remote '$ORIGIN'."
+		fi
+		if flag pushproduction; then
+			git_do push "$ORIGIN" "$MASTER_BRANCH" || die "Could not push branch '$MASTER_BRANCH' to remote '$ORIGIN'."
+		fi
+		if noflag notag && flag pushtag; then
+			git_do push --tags "$ORIGIN" || die "Could not push tags to remote '$ORIGIN'."
+		fi
+	fi
+
 	# Delete branch
 	if noflag keep; then
 
@@ -204,18 +216,6 @@ _finish_from_develop() {
 		# no more branches: we can safely remove config section
 		if ! git_remote_branch_exists "$ORIGIN/$BRANCH" -a ! git_local_branch_exists "$BRANCH"; then
 			gitflow_config_remove_base_section "$BRANCH"
-		fi
-	fi
-
-	if flag push; then
-		if flag pushdevelop; then
-			git_do push "$ORIGIN" "$DEVELOP_BRANCH" || die "Could not push branch '$DEVELOP_BRANCH' to remote '$ORIGIN'."
-		fi
-		if flag pushproduction; then
-			git_do push "$ORIGIN" "$MASTER_BRANCH" || die "Could not push branch '$MASTER_BRANCH' to remote '$ORIGIN'."
-		fi
-		if noflag notag && flag pushtag; then
-			git_do push --tags "$ORIGIN" || die "Could not push tags to remote '$ORIGIN'."
 		fi
 	fi
 


### PR DESCRIPTION
This addresses an issue when using a feature branch that is associated with a pull request on GitHub, when the develop branch is merge-protected.  In the current implementation of `git flow feature finish`, the remote feature branch is deleted before the merged local develop branch has been pushed.  This causes the pull request to be closed before the changes have been merged, so the approval no longer applies and the push is rejected.  To a certain extent this seems to be a bug with GitHub, but I don't see a drawback to pushing before deleting the remote branch.