### PR TITLE
implement hook logic to rename branch in bugfix and feature (fix #352)

### DIFF
--- a/git-flow-bugfix
+++ b/git-flow-bugfix
@@ -205,6 +205,9 @@ F,[no]fetch      Fetch from origin before performing local operation
 		git_fetch_branch "$ORIGIN" "$base"
 	fi
 
+	# hook for branch renaming
+	run_prepare_name_branch_hook "$NAME"
+
 	# Sanity checks
 	require_branch_absent "$BRANCH"
 

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -40,7 +40,8 @@
 initialize() {
 	require_git_repo
 	require_gitflow_initialized
-	git config --get gitflow.prefix.feature >/dev/null 2>&1 || die "Feature prefix not set. Please run 'git flow init'."
+	git config --get gitflow.prefix.feature >/dev/null 2>&1 || die "Feature prefix not set. Please run 'git flow
+init'."
 	gitflow_load_settings
 	PREFIX=$(git config --get gitflow.prefix.feature)
 }
@@ -205,6 +206,9 @@ F,[no]fetch      Fetch from origin before performing local operation
 		git_fetch_branch "$ORIGIN" "$base"
 	fi
 
+	# hook for branch renaming
+	run_prepare_name_branch_hook "$NAME"
+
 	# Sanity checks
 	require_branch_absent "$BRANCH"
 
@@ -213,8 +217,6 @@ F,[no]fetch      Fetch from origin before performing local operation
 	if git_remote_branch_exists "$ORIGIN/$base"; then
 		require_branches_equal "$base" "$ORIGIN/$base"
 	fi
-
-	run_pre_hook "$NAME" "$ORIGIN" "$BRANCH" "$base"
 
 	gitflow_config_set_base_branch $base $BRANCH
 
@@ -299,7 +301,8 @@ no-ff!                 Never fast-forward during the merge
 
 	BASE_BRANCH=$(gitflow_config_get_base_branch $BRANCH)
 	BASE_BRANCH=${BASE_BRANCH:-$DEVELOP_BRANCH}
-	git_local_branch_exists "$BASE_BRANCH" || die "The base '$BASE_BRANCH' doesn't exists locally or is not a branch. Can't finish the feature branch '$BRANCH'."
+	git_local_branch_exists "$BASE_BRANCH" || die "The base '$BASE_BRANCH' doesn't exists locally or is not a
+branch. Can't finish the feature branch '$BRANCH'."
 
 	# Detect if we're restoring from a merge conflict
 	if [ -f "$DOT_GIT_DIR/.gitflow/MERGE_BASE" ]; then
@@ -400,7 +403,8 @@ no-ff!                 Never fast-forward during the merge
 		fi
 	else
 		git_do merge --squash "$BRANCH"
-		flag squash_info && gitflow_create_squash_message "Merged feature branch '$BRANCH'" "$BASE_BRANCH" "$BRANCH" > "$DOT_GIT_DIR/SQUASH_MSG"
+		flag squash_info && gitflow_create_squash_message "Merged feature branch '$BRANCH'" "$BASE_BRANCH"
+"$BRANCH" > "$DOT_GIT_DIR/SQUASH_MSG"
 		git_do commit
 	fi
 
@@ -470,7 +474,8 @@ helper_finish_cleanup() {
 	fi
 
 	if flag push; then
-		git_do push "$ORIGIN" "$BASE_BRANCH" || die "Could not push branch '$BASE_BRANCH' to remote '$ORIGIN'."
+		git_do push "$ORIGIN" "$BASE_BRANCH" || die "Could not push branch '$BASE_BRANCH' to remote
+'$ORIGIN'."
 	fi
 
 	echo
@@ -665,7 +670,8 @@ p,[no]preserve-merges  Preserve merges
 
 	require_branch "$BRANCH"
 
-	git_local_branch_exists "$BASE_BRANCH" || die "The base '$BASE_BRANCH' doesn't exists locally or is not a branch. Can't rebase the feature branch '$BRANCH'."
+	git_local_branch_exists "$BASE_BRANCH" || die "The base '$BASE_BRANCH' doesn't exists locally or is not a
+branch. Can't rebase the feature branch '$BRANCH'."
 
 	git_do checkout -q "$BRANCH"  || die "Could not check out branch '$BRANCH'."
 	if flag interactive; then
@@ -703,7 +709,8 @@ showcommands!    Show git commands while executing them
 	# Define flags
 	DEFINE_boolean 'rebase' false "pull with rebase" r
 
-	warn "The command 'git flow feature pull' will be deprecated per version 2.0.0. Use 'git flow feature track' instead."
+	warn "The command 'git flow feature pull' will be deprecated per version 2.0.0. Use 'git flow feature track'
+instead."
 
 	# Parse arguments
 	parse_remote_name "$@"
@@ -739,7 +746,8 @@ showcommands!    Show git commands while executing them
 		# remote changes in
 		if flag rebase; then
 			if ! git_do pull --rebase -q "$REMOTE" "$BRANCH"; then
-				warn "Pull was aborted. There might be conflicts during rebase or '$REMOTE' might be inaccessible."
+				warn "Pull was aborted. There might be conflicts during rebase or '$REMOTE' might be
+inaccessible."
 				exit 1
 			fi
 		else
@@ -749,7 +757,8 @@ showcommands!    Show git commands while executing them
 		echo "Pulled $REMOTE's changes into $BRANCH."
 	else
 		# Setup the local branch clone for the first time
-		git_do fetch -q "$REMOTE" "$BRANCH" ||  die "Could not fetch branch '$BRANCH' from remote '$REMOTE'."     # Stores in FETCH_HEAD
+		git_do fetch -q "$REMOTE" "$BRANCH" ||  die "Could not fetch branch '$BRANCH' from remote '$REMOTE'."
+   # Stores in FETCH_HEAD
 		git_do branch --no-track "$BRANCH" FETCH_HEAD || die "Branch failed."
 		git_do checkout -q "$BRANCH" || die "Could not check out branch '$BRANCH'."
 		echo "Created local branch $BRANCH based on $REMOTE's $BRANCH."

--- a/gitflow-common
+++ b/gitflow-common
@@ -130,7 +130,8 @@ git_current_branch() {
 	local branch_name
 
 	branch_name="$(git symbolic-ref --quiet HEAD)"
-	[ -z $branch_name ] && branch_name="(unnamed branch)" || branch_name="$(git for-each-ref --format='%(refname:short)' $branch_name)"
+	[ -z $branch_name ] && branch_name="(unnamed branch)" || branch_name="$(git for-each-ref --
+format='%(refname:short)' $branch_name)"
 	echo "$branch_name"
 }
 
@@ -619,7 +620,7 @@ gitflow_rename_branch() {
 		NAME=$2
 	fi
 	BRANCH=${PREFIX}${NAME}
-	NEW_BRANCH=${PREFIX}${NEW_NAME}
+	NEW_NAME=${PREFIX}${NEW_NAME}
 
 	if [ -z "$NEW_NAME" ]; then
 		die "No new name given."
@@ -633,16 +634,16 @@ gitflow_rename_branch() {
 
 	# Sanity checks
 	require_branch "$BRANCH"
-	require_branch_absent "$NEW_BRANCH"
+	require_branch_absent "$NEW_NAME"
 
 	run_pre_hook "$NAME" "$ORIGIN" "$BRANCH"
-	git_do branch -m "$BRANCH" "$NEW_BRANCH" || die "Error renaming branch '$BRANCH' to '$NEW_BRANCH'"
-	gitflow_config_rename_sections "$BRANCH" "$NEW_BRANCH"
+	git_do branch -m "$BRANCH" "$NEW_NAME" || die "Error renaming branch '$BRANCH' to '$NEW_NAME'"
+	gitflow_config_rename_sections "$BRANCH" "$NEW_NAME"
 	run_post_hook "$NAME" "$ORIGIN" "$BRANCH"
 
 	echo
 	echo "Summary of actions:"
-	echo "- Branch '$BRANCH' has been renamed to '$NEW_BRANCH'."
+	echo "- Branch '$BRANCH' has been renamed to '$NEW_NAME'."
 	echo "- You are now on branch '$(git_current_branch)'"
 	echo
 }
@@ -656,7 +657,8 @@ require_git_repo() {
 
 require_gitflow_initialized() {
 	gitflow_is_initialized || die "Not a gitflow-enabled repo yet. Please run 'git flow init' first."
-	$(git config --get gitflow.prefix.versiontag >/dev/null 2>&1) || die "Version tag not set. Please run 'git flow init'."
+	$(git config --get gitflow.prefix.versiontag >/dev/null 2>&1) || die "Version tag not set. Please run 'git
+flow init'."
 }
 
 require_clean_working_tree() {
@@ -757,6 +759,42 @@ run_filter_hook() {
 			echo $return
 	else
 		echo "$@"
+	fi
+}
+
+#
+# run_prepare_name_branch_hook
+#
+# Looks for a Git hook script called
+#
+#     pre-flow-<subcmd>-prepare-name-branch
+#
+# If such a hook script exists and is executable, it is called with the given
+# positional arguments.  If its return code non-zero, the git-flow action is
+# aborted.
+#
+run_prepare_name_branch_hook() {
+	local scriptfile exitcode
+	echo "in run_prepare_name_branch_hook"
+
+	scriptfile="${HOOKS_DIR}/pre-flow-${SUBCOMMAND}-prepare-name-branch"
+	exitcode=0
+	if [ -x "$scriptfile" ]; then
+		read NEW_NAME REST <<< $("$scriptfile" "$@")
+		exitcode=$?
+
+		if [ $exitcode -gt 0 ]; then
+			die "Hook command $scriptfile ended with exit code $exitcode."
+		fi
+		if [ ! -z "$NEW_NAME" ]; then
+			if [ ! -z "$REST" ]; then
+				die "Hook command $scriptfile returned more than 1 argument instead of 1 (BRANCH)"
+			else
+				echo "Renaming $NAME to $NEW_NAME"
+				NAME=$NEW_NAME
+				BRANCH=$PREFIX$NEW_NAME
+			fi
+		fi
 	fi
 }
 

--- a/gitflow-common
+++ b/gitflow-common
@@ -130,8 +130,7 @@ git_current_branch() {
 	local branch_name
 
 	branch_name="$(git symbolic-ref --quiet HEAD)"
-	[ -z $branch_name ] && branch_name="(unnamed branch)" || branch_name="$(git for-each-ref --
-format='%(refname:short)' $branch_name)"
+	[ -z $branch_name ] && branch_name="(unnamed branch)" || branch_name="$(git for-each-ref --format='%(refname:short)' $branch_name)"
 	echo "$branch_name"
 }
 
@@ -780,12 +779,13 @@ run_prepare_name_branch_hook() {
 	scriptfile="${HOOKS_DIR}/pre-flow-${SUBCOMMAND}-prepare-name-branch"
 	exitcode=0
 	if [ -x "$scriptfile" ]; then
-		read NEW_NAME REST <<< $("$scriptfile" "$@")
+		OUTPUT=$("$scriptfile" "$@")
 		exitcode=$?
-
+        echo "exitcode=" $exitcode
 		if [ $exitcode -gt 0 ]; then
 			die "Hook command $scriptfile ended with exit code $exitcode."
 		fi
+		read NEW_NAME REST <<< $OUTPUT
 		if [ ! -z "$NEW_NAME" ]; then
 			if [ ! -z "$REST" ]; then
 				die "Hook command $scriptfile returned more than 1 argument instead of 1 (BRANCH)"

--- a/hooks/pre-flow-bugfix-prepare-name-branch
+++ b/hooks/pre-flow-bugfix-prepare-name-branch
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Runs before git flow bugfix start
+#
+# Positional arguments:
+# $1    The friendly name of the branch
+#
+# The following variables are available as they are exported by git-flow:
+#
+# MASTER_BRANCH - The branch defined as Master
+# DEVELOP_BRANCH - The branch defined as Develop
+#
+NAME=$1
+
+# Implement your script here that outputs to stdout the new name of the branch
+
+# To terminate the git-flow action, return a non-zero exit code.
+exit 0

--- a/hooks/pre-flow-feature-prepare-name-branch
+++ b/hooks/pre-flow-feature-prepare-name-branch
@@ -1,0 +1,18 @@
+#!/bin/sh
+#
+# Runs before git flow feature start
+#
+# Positional arguments:
+# $1    The friendly name of the branch
+#
+# The following variables are available as they are exported by git-flow:
+#
+# MASTER_BRANCH - The branch defined as Master
+# DEVELOP_BRANCH - The branch defined as Develop
+#
+NAME=$1
+
+# Implement your script here that outputs to stdout the new name of the branch
+
+# To terminate the git-flow action, return a non-zero exit code.
+exit 0


### PR DESCRIPTION
added two hooks pre-flow-bugfix-prepare-name-branch and pre-flow-feature-prepare-name-branch that allows branch renaming before creation (call during git flow bugfix/feature start)
use case: create a branch by giving an issue ID (github, jira, pivotal, ...) and let the hook adapt the branch name to include the issue description (as the ID is not user friendly). The logic to retrieve the issue description from the ID and adapting the name of the branch can be implemented in the 2 new hooks