### PR TITLE
Improve portability of shebang

### DIFF
--- a/contrib/gitflow-installer.sh
+++ b/contrib/gitflow-installer.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # git-flow make-less installer for *nix systems, by Rick Osborne
 # Based on the git-flow core Makefile:


### PR DESCRIPTION
Some modern systems do not support `/bin/bash`, and prefer the more
universal `/usr/bin/env bash`. This change allows such operating systems
(like NixOS) to execute ./contrib/gitflow-installer.sh

`/bin/sh` is universal, so those shebangs are left alone.