### PR TITLE
Add .gitattributes that ensures scripts have UNIX line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+*.awk  text eol=lf
+*.sed  text eol=lf
+*.sh   text eol=lf


### PR DESCRIPTION
Fixes #191 
I've also edited the wiki instructions page regarding Windows installation with Cygwin