### PR TITLE
Fix branch existence checks of `hotfix track`

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -345,17 +345,18 @@ showcommands!     Show git commands while executing them
 
 	# Sanity checks
 	require_clean_working_tree
-	require_branch_absent "$BRANCH"
-	git_do fetch -q "$ORIGIN"
-	require_branch "$ORIGIN/$BRANCH"
+	require_local_branch_absent "$BRANCH"
+
+	git_do fetch -q "$ORIGIN"  || die "Could not fetch branch '$BRANCH' from remote '$ORIGIN'."
+	git_remote_branch_exists "$ORIGIN/$BRANCH"
 
 	# Create tracking branch
-	git_do checkout -b "$BRANCH" "$ORIGIN/$BRANCH"
+	git_do checkout -b "$BRANCH" "$ORIGIN/$BRANCH" || die "Could not create branch '$BRANCH'."
 
 	echo
 	echo "Summary of actions:"
 	echo "- A new remote tracking branch '$BRANCH' was created"
-	echo "- You are now on branch '$BRANCH'"
+	echo "- You are now on branch '$(git_current_branch)'"
 	echo
 }
 


### PR DESCRIPTION
Fixes https://github.com/petervanderdoes/gitflow-avh/issues/248.

I've fixed branch existence checks of `hotfix track` command with reference to the following `release track` command.

https://github.com/petervanderdoes/gitflow-avh/blob/3e05e2a446586f621eaa5e3ccf647a3ba8e120b1/git-flow-release#L936-L969

Please check my changes and merge them if you can. Thanks!