### PR TITLE
Allow multiple release branches in the same way multiple hotfixes are allowed

### DIFF
--- a/git-flow-release
+++ b/git-flow-release
@@ -565,7 +565,9 @@ v,verbose!           Verbose (more) output
 	require_base_is_local_branch "$base"
 	gitflow_require_version_arg
 
-	require_no_existing_release_branches
+	if ! $(git config --bool --get gitflow.multi-release 2>&1); then
+		require_no_existing_release_branches
+	fi
 
 	# Sanity checks
 	git_config_bool_exists "gitflow.allowdirty" || require_clean_working_tree


### PR DESCRIPTION
This is a very simple change to mirror the setting `gitflow.multi-hotfix` so that we also have `gitflow.multi-release` to allow multiple active release branches.

Our release process is such that we can sometimes need multiple release branches active at the same time (e.g. to prepare a patch release which takes a short amount of time whilst preparing a major release which will take longer so the two overlap).