### PR TITLE
Introducing pre-start feature and bugfix name filtering

### DIFF
--- a/git-flow-bugfix
+++ b/git-flow-bugfix
@@ -197,6 +197,14 @@ F,[no]fetch      Fetch from origin before performing local operation
 	eval set -- "${FLAGS_ARGV}"
 	base=${2:-$DEVELOP_BRANCH}
 
+	# Run filter on the name
+	NAME=$(run_filter_hook bugfix-start-name $NAME)
+	if [ $? -eq 127 ]; then
+		die $NAME
+	fi
+
+	BRANCH="$PREFIX$NAME"
+
 	require_base_is_local_branch "$base"
 	gitflow_require_name_arg
 

--- a/git-flow-feature
+++ b/git-flow-feature
@@ -197,6 +197,14 @@ F,[no]fetch      Fetch from origin before performing local operation
 	eval set -- "${FLAGS_ARGV}"
 	base=${2:-$DEVELOP_BRANCH}
 
+	# Run filter on the name
+	NAME=$(run_filter_hook feature-start-name $NAME)
+	if [ $? -eq 127 ]; then
+		die $NAME
+	fi
+
+	BRANCH="$PREFIX$NAME"
+
 	require_base_is_local_branch "$base"
 	gitflow_require_name_arg
 

--- a/gitflow-common
+++ b/gitflow-common
@@ -749,12 +749,12 @@ run_filter_hook() {
 	shift
 	scriptfile="${HOOKS_DIR}/filter-flow-${command}"
 	if [ -x "$scriptfile" ]; then
-		return=`$scriptfile "$@"`
+		return=`$scriptfile "$*"`
 		if [ $? -eq 127 ]; then
 			echo "$return"
 			exit 127
 		fi
-			echo $return
+		echo $return
 	else
 		echo "$@"
 	fi

--- a/hooks/filter-flow-bugfix-start-name
+++ b/hooks/filter-flow-bugfix-start-name
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Runs during git flow feature start
+#
+# Positional arguments:
+# $1    Name
+#
+# Return NAME - When NAME is returned empty, git-flow will stop as the
+# Name is necessary
+#
+# The following variables are available as they are exported by git-flow:
+#
+# MASTER_BRANCH - The branch defined as Master
+# DEVELOP_BRANCH - The branch defined as Develop
+#
+NAME=$1
+
+# Implement your script here.
+
+# Return the NAME
+echo ${NAME}
+exit 0

--- a/hooks/filter-flow-feature-start-name
+++ b/hooks/filter-flow-feature-start-name
@@ -1,0 +1,22 @@
+#!/bin/sh
+#
+# Runs during git flow feature start
+#
+# Positional arguments:
+# $1    Name
+#
+# Return NAME - When NAME is returned empty, git-flow will stop as the
+# name is necessary
+#
+# The following variables are available as they are exported by git-flow:
+#
+# MASTER_BRANCH - The branch defined as Master
+# DEVELOP_BRANCH - The branch defined as Develop
+#
+NAME=$1
+
+# Implement your script here.
+
+# Return the NAME
+echo ${NAME}
+exit 0


### PR DESCRIPTION
### Summary

Pre-start `NAME` filtering for `feature` and `bugflix` flows.

This mostly replicates the _pre-start_ `VERSION` filtering performed for `release`, `hotfix` and `support` flows, to facilitate standardised naming - to your spec - for features and bugfixes that most tooling can work with.

### Motivation
Many of us developers are at least familiar with JIRA - or similar management tools - and, where possible, may leverage any integrations possible to facilitate a smooth workflow.

Different tools and integrations can not all handle the same free-form feature and bugfix branch names; one tool might handle `[`/`]` brackets fine, the next might meltdown... the meltdown possibilities are endless.

What would be nice would be to copy the title of your JIRA ticket and use that as the feature/bugfix name, but have it automatically whipped into shape that all tools and integrations are happy.

### An example developer setup

I tend to replicate this setup at any and every client possible:
- JIRA
- Git with Git Flow AVH installed
- IntelliiJ IDEA with Git, Git Flow and Task Management plugins installed
  - **Tools / Tasks** configured to talk to JIRA:
    - _Changelist name format_ set to `[{id}] {summary}`
    - _Feature branch name format_ set to `${id}-${summary}`, replace space with `_` (undescore)
    - _Commit Message_ template enabled and set to `[{id}] {summary}` (server config)
  - **Version Control / Issue Navigation** configured with `[A-Z]+\-\d+` mapping to JIRA

### How that works

With this setup, from IntelliJ I can open or switch to a task assigned to me in JIRA and it will mostly do the right thing.

If for whatever reason, the BA, Product Owner or Scrum Master created a JIRA with weirdness in the name, it could all or partially meltdown... or at least look weird in IntelliJ and weirder still in the Terminal shell e.g. with `PS1` command prompt integration enabled.

### The hope for `NAME` filtering

The hope is that Git Flow and these new `NAME` filters will have the final say on what the feature or bugfix branch name will be, hence regardless what the orchestrating tool is, that _essentially_ requested a new feature or bugfix be started, it will automatically work with the name Git Flow decides.