### PR TITLE
git-flow: prefer "-f" readlink(1) option to "-e"

### DIFF
--- a/git-flow
+++ b/git-flow
@@ -46,7 +46,7 @@ fi
 # git-flow file is a symbolic link
 case $(uname -s) in
 Linux)
-	export GITFLOW_DIR=$(dirname "$(readlink -e "$0")")
+	export GITFLOW_DIR=$(dirname "$(readlink -f "$0")")
 	;;
 FreeBSD|OpenBSD|NetBSD)
 	export FLAGS_GETOPT_CMD='/usr/local/bin/getopt'


### PR DESCRIPTION
Since $0 can be assumed to exist, these two flags behave identially, but
readlink(1) from busybox does not support "-e", only GNU Coreutils does.
