### PR TITLE
Finish hotfix should checkout the master branch before tagging

### DIFF
--- a/git-flow-hotfix
+++ b/git-flow-hotfix
@@ -532,6 +532,7 @@ T,tagname!            Use given tag name
 		# In case a previous attempt to finish this release branch has failed,
 		# but the tag was set successful, we skip it now
 		if ! git_tag_exists "$VERSION_PREFIX$TAGNAME"; then
+			git_do checkout "$MASTER_BRANCH" || die "Could not check out branch '$MASTER_BRANCH'."
 			if [ "$FLAGS_message" != "" ] && [ "$FLAGS_messagefile" != "" ]; then
 				die "Use either -m,--message or -f,--messagefile. Can not use both options at the same time"
 			fi


### PR DESCRIPTION
In some situations, the tag after finishing a hotfix is not placed on the master branch commit, but is on the develop branch commit as described in #416 
Added a checkout of the master branch before tagging, identically to how the finish release script is doing.